### PR TITLE
fix(ui): make the context menu follow the system theme

### DIFF
--- a/Fader/UI/StatusItemMenu.swift
+++ b/Fader/UI/StatusItemMenu.swift
@@ -33,6 +33,9 @@ final class StatusItemMenuController: NSObject {
 
         let menu = NSMenu()
         menu.autoenablesItems = false
+        // The status bar window is pinned dark; without this the menu
+        // inherits that and ignores the system theme.
+        menu.appearance = NSApp.effectiveAppearance
 
         let header = NSMenuItem(title: "Fader \(Bundle.main.shortVersion)", action: nil, keyEquivalent: "")
         header.isEnabled = false


### PR DESCRIPTION
The status-bar window pins a dark appearance, and the right-click menu popped for its content view inherited it — the menu stayed dark in light mode. Pointing the menu at the app's effective appearance at pop-up time restores the standard system-following behavior; the native path (NSStatusItem.menu) is unreachable under MenuBarExtra(.window).

Verify by opening the menu and toggling System Settings light/dark.