### PR TITLE
feat(ui): pick device icons from transport, data source, and BT class

### DIFF
--- a/Fader/Audio/AudioDeviceMonitor.swift
+++ b/Fader/Audio/AudioDeviceMonitor.swift
@@ -8,6 +8,12 @@ struct AudioDevice: Identifiable, Hashable {
     let uid: String
     let name: String
     let transport: UInt32
+    /// Per-scope data sources ('hdpn', 'ispk', 'imic', …), 0 when absent.
+    /// Read at construction; on Apple Silicon plug/unplug swaps the HAL
+    /// device itself, so the values can't go stale within one device's
+    /// lifetime.
+    let outputDataSource: UInt32
+    let inputDataSource: UInt32
 
     var isBluetooth: Bool {
         transport == kAudioDeviceTransportTypeBluetooth || transport == kAudioDeviceTransportTypeBluetoothLE
@@ -19,22 +25,20 @@ struct AudioDevice: Identifiable, Hashable {
         uid.lowercased().hasPrefix(bluetoothID.lowercased())
     }
 
-    /// SF Symbol matching the device's transport type.
-    var symbolName: String {
-        switch transport {
-        case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
-            "airpods.gen3"
-        case kAudioDeviceTransportTypeBuiltIn:
-            "laptopcomputer"
-        case kAudioDeviceTransportTypeUSB:
-            "cable.connector"
-        case kAudioDeviceTransportTypeDisplayPort, kAudioDeviceTransportTypeHDMI:
-            "display"
-        case kAudioDeviceTransportTypeAirPlay:
-            "airplay.audio"
-        default:
-            "hifispeaker"
+    /// SF Symbol for the row icon. The paired IOBluetooth peer, when one
+    /// matches by MAC, carries the minor class and the canonical name.
+    func symbolName(direction: AudioDirection, bluetoothPeer: BluetoothAudioDevice?) -> String {
+        if isBluetooth {
+            return DeviceSymbol.bluetooth(
+                name: bluetoothPeer?.name ?? name,
+                minorClass: bluetoothPeer?.minorClass ?? 0
+            )
         }
+        return DeviceSymbol.wired(
+            transport: transport,
+            dataSource: direction == .output ? outputDataSource : inputDataSource,
+            direction: direction
+        )
     }
 }
 
@@ -47,7 +51,12 @@ extension AudioDevice {
         else { return nil }
         var transport: UInt32 = 0
         try? id.read(kAudioDevicePropertyTransportType, into: &transport)
-        self.init(id: id, uid: uid, name: name, transport: transport)
+        var outputDataSource: UInt32 = 0
+        try? id.read(kAudioDevicePropertyDataSource, scope: kAudioDevicePropertyScopeOutput, into: &outputDataSource)
+        var inputDataSource: UInt32 = 0
+        try? id.read(kAudioDevicePropertyDataSource, scope: kAudioDevicePropertyScopeInput, into: &inputDataSource)
+        self.init(id: id, uid: uid, name: name, transport: transport,
+                  outputDataSource: outputDataSource, inputDataSource: inputDataSource)
     }
 }
 

--- a/Fader/Audio/BluetoothAudioMonitor.swift
+++ b/Fader/Audio/BluetoothAudioMonitor.swift
@@ -9,6 +9,13 @@ struct BluetoothAudioDevice: Identifiable, Hashable {
     let id: String
     let name: String
     let isConnected: Bool
+    /// Minor class of the audio major (headphones vs. loudspeaker), 0 when
+    /// the manufacturer didn't bother.
+    let minorClass: UInt32
+
+    var symbolName: String {
+        DeviceSymbol.bluetooth(name: name, minorClass: minorClass)
+    }
 }
 
 /// Lists paired Bluetooth audio devices and connects or disconnects them.
@@ -17,7 +24,7 @@ struct BluetoothAudioDevice: Identifiable, Hashable {
 @MainActor
 @Observable
 final class BluetoothAudioMonitor {
-    private static let logger = Logger(subsystem: "dev.pantafive.fader", category: "BluetoothAudioMonitor")
+    private nonisolated static let logger = Logger(subsystem: "dev.pantafive.fader", category: "BluetoothAudioMonitor")
 
     private(set) var paired: [BluetoothAudioDevice] = []
     /// Addresses with a connect/disconnect operation in flight.
@@ -47,10 +54,12 @@ final class BluetoothAudioMonitor {
                 guard let address = device.addressString else { return nil }
                 // Major device class 0x04 = audio (headphones, speakers, headsets).
                 guard device.deviceClassMajor == kBluetoothDeviceClassMajorAudio else { return nil }
+                Self.logger.debug("Paired \(device.name ?? address): minor class \(device.deviceClassMinor)")
                 return BluetoothAudioDevice(
                     id: address,
                     name: device.name ?? address,
-                    isConnected: device.isConnected()
+                    isConnected: device.isConnected(),
+                    minorClass: UInt32(device.deviceClassMinor)
                 )
             }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }

--- a/Fader/Audio/DeviceSymbol.swift
+++ b/Fader/Audio/DeviceSymbol.swift
@@ -1,0 +1,137 @@
+import CoreAudio
+import Darwin
+import IOKit
+
+/// Maps a device's identity signals to an SF Symbol. The cascade runs from
+/// reliable to brittle — transport type, then jack data source / Bluetooth
+/// minor class, then Apple-gear name matching — and a brittle signal only
+/// refines a class, never downgrades it: renamed AirPods fall back to the
+/// minor-class glyph, a device that reports nothing keeps its transport glyph.
+enum DeviceSymbol {
+    // MARK: - Wired
+
+    /// Built-in jack data sources (IOAudioTypes.h port subtypes).
+    private static let headphonesSource: UInt32 = 0x6864_706E // 'hdpn'
+    private static let externalSpeakerSource: UInt32 = 0x6573_706B // 'espk'
+    private static let externalMicSource: UInt32 = 0x656D_6963 // 'emic'
+    private static let lineSource: UInt32 = 0x6C69_6E65 // 'line' (out and in)
+
+    /// Symbol for a non-Bluetooth device. `dataSource` is the device's data
+    /// source in the displayed direction, 0 when it exposes none. `mac` is
+    /// injectable for tests only.
+    static func wired(transport: UInt32,
+                      dataSource: UInt32,
+                      direction: AudioDirection,
+                      mac: String = currentMac) -> String {
+        switch transport {
+        case kAudioDeviceTransportTypeBuiltIn:
+            builtIn(dataSource: dataSource, direction: direction, mac: mac)
+        case kAudioDeviceTransportTypeHDMI, kAudioDeviceTransportTypeDisplayPort:
+            "display"
+        case kAudioDeviceTransportTypeAirPlay:
+            "airplay.audio"
+        case kAudioDeviceTransportTypeContinuityCaptureWired, kAudioDeviceTransportTypeContinuityCaptureWireless:
+            "iphone"
+        case kAudioDeviceTransportTypeVirtual:
+            "waveform"
+        case kAudioDeviceTransportTypeAggregate:
+            // Someone else's multi-output (ours are filtered out): a stack
+            // of devices, not one speaker.
+            "hifispeaker.2"
+        case kAudioDeviceTransportTypeUSB, kAudioDeviceTransportTypeThunderbolt,
+             kAudioDeviceTransportTypeFireWire, kAudioDeviceTransportTypePCI,
+             kAudioDeviceTransportTypeAVB:
+            // A wired box of unknown nature: DAC, dock, interface. In the
+            // input list it is at least certainly a microphone source.
+            direction == .input ? "mic" : "cable.connector"
+        default:
+            direction == .input ? "mic" : "hifispeaker"
+        }
+    }
+
+    private static func builtIn(dataSource: UInt32, direction: AudioDirection, mac: String) -> String {
+        switch direction {
+        case .output:
+            switch dataSource {
+            case headphonesSource: "headphones"
+            case externalSpeakerSource, lineSource: "hifispeaker"
+            // 'ispk' or no data source — the Mac's own speakers.
+            default: mac
+            }
+        case .input:
+            switch dataSource {
+            case externalMicSource, lineSource: "mic"
+            // 'imic' or no data source — the Mac's own microphone.
+            default: mac
+            }
+        }
+    }
+
+    // MARK: - Bluetooth
+
+    /// Minor device classes of the audio/video major (Bluetooth Assigned
+    /// Numbers). Set by the manufacturer; plenty of gear reports 0.
+    private enum BTMinor {
+        static let microphone: UInt32 = 0x04
+        static let loudspeaker: UInt32 = 0x05
+        static let portableAudio: UInt32 = 0x07
+        static let carAudio: UInt32 = 0x08
+        static let hiFiAudio: UInt32 = 0x0A
+    }
+
+    static func bluetooth(name: String, minorClass: UInt32) -> String {
+        let lower = name.lowercased()
+        if lower.contains("airpods max") { return "airpodsmax" }
+        if lower.contains("airpods pro") { return "airpodspro" }
+        if lower.contains("airpods") { return "airpods.gen3" }
+        return switch minorClass {
+        case BTMinor.loudspeaker, BTMinor.portableAudio, BTMinor.carAudio, BTMinor.hiFiAudio:
+            "hifispeaker"
+        case BTMinor.microphone:
+            "mic"
+        // Headset, hands-free, headphones — and uncategorized, where
+        // headphones are by far the likeliest BT audio device.
+        default:
+            "headphones"
+        }
+    }
+
+    // MARK: - This Mac
+
+    /// Glyph for the machine's own speakers and microphone, like the System
+    /// Settings Sound list.
+    static let currentMac: String = mac(model: readModel() ?? "")
+
+    /// Matches both marketing names ("Mac mini (M1, 2020)") and Intel model
+    /// identifiers ("Macmini8,1"). Apple Silicon identifiers are opaque
+    /// ("Mac16,10"), but those machines expose the marketing name instead.
+    static func mac(model: String) -> String {
+        let lower = model.lowercased()
+        if lower.contains("macbook") { return "laptopcomputer" }
+        if lower.contains("imac") { return "desktopcomputer" }
+        if lower.contains("mac mini") || lower.contains("macmini") { return "macmini" }
+        if lower.contains("mac studio") || lower.contains("macstudio") { return "macstudio" }
+        if lower.contains("mac pro") || lower.contains("macpro") { return "macpro.gen3" }
+        return "laptopcomputer" // most Macs; also the pre-cascade default
+    }
+
+    /// Marketing name from the device tree (Apple Silicon), else the model
+    /// identifier from sysctl (Intel).
+    private static func readModel() -> String? {
+        let entry = IORegistryEntryFromPath(kIOMainPortDefault, "IODeviceTree:/product")
+        if entry != 0 {
+            defer { IOObjectRelease(entry) }
+            if let data = IORegistryEntryCreateCFProperty(
+                entry, "product-name" as CFString, kCFAllocatorDefault, 0
+            )?.takeRetainedValue() as? Data,
+                let name = String(bytes: data, encoding: .utf8) {
+                return name.trimmingCharacters(in: .controlCharacters)
+            }
+        }
+        var size = 0
+        guard sysctlbyname("hw.model", nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("hw.model", &buffer, &size, nil, 0) == 0 else { return nil }
+        return String(cString: buffer)
+    }
+}

--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -73,6 +73,11 @@ final class MixerEngine {
         apply(entry, to: app)
     }
 
+    /// Paired IOBluetooth peer of a HAL device, when one matches by MAC.
+    func bluetoothPeer(for device: AudioDevice) -> BluetoothAudioDevice? {
+        bluetooth.paired.first { device.matches(bluetoothID: $0.id) }
+    }
+
     /// Connects Bluetooth headphones and routes output to them once CoreAudio
     /// picks the device up.
     func connectBluetooth(_ device: BluetoothAudioDevice) {

--- a/Fader/UI/ActiveOutputsSection.swift
+++ b/Fader/UI/ActiveOutputsSection.swift
@@ -47,10 +47,13 @@ struct ActiveOutputsSection: View {
     private func activeRow(_ row: Row) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
-                Image(systemName: row.device.symbolName)
-                    .font(.system(size: 13))
-                    .foregroundStyle(Color.accentColor)
-                    .frame(width: 18)
+                Image(systemName: row.device.symbolName(
+                    direction: .output,
+                    bluetoothPeer: engine.bluetoothPeer(for: row.device)
+                ))
+                .font(.system(size: 13))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 18)
                 Text(row.device.name)
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)

--- a/Fader/UI/DeviceRowView.swift
+++ b/Fader/UI/DeviceRowView.swift
@@ -40,12 +40,12 @@ struct DeviceRowView: View {
     }
 
     private var bluetoothPeer: BluetoothAudioDevice? {
-        engine.bluetooth.paired.first { device.matches(bluetoothID: $0.id) }
+        engine.bluetoothPeer(for: device)
     }
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: device.symbolName)
+            Image(systemName: device.symbolName(direction: monitor.direction, bluetoothPeer: bluetoothPeer))
                 .font(.system(size: 13))
                 .foregroundStyle(isActive ? Color.accentColor : .secondary)
                 .frame(width: 18)
@@ -173,7 +173,7 @@ struct BluetoothRowView: View {
             engine.connectBluetooth(device)
         } label: {
             HStack(spacing: 8) {
-                Image(systemName: "headphones")
+                Image(systemName: device.symbolName)
                     .font(.system(size: 13))
                     .foregroundStyle(.tertiary)
                     .frame(width: 18)

--- a/Tests/DeviceSymbolTests.swift
+++ b/Tests/DeviceSymbolTests.swift
@@ -1,0 +1,97 @@
+import Testing
+
+@Suite("DeviceSymbol")
+struct DeviceSymbolTests {
+    // Four-char codes mirrored from CoreAudio/IOAudioTypes; the production
+    // constants are private by design.
+    private let builtIn: UInt32 = 0x626C_746E // 'bltn'
+    private let usb: UInt32 = 0x7573_6220 // 'usb '
+    private let thunderbolt: UInt32 = 0x7468_756E // 'thun'
+    private let hdmi: UInt32 = 0x6864_6D69 // 'hdmi'
+    private let airPlay: UInt32 = 0x6169_7270 // 'airp'
+    private let virtualTransport: UInt32 = 0x7669_7274 // 'virt'
+    private let continuityWireless: UInt32 = 0x6363_776C // 'ccwl'
+    private let aggregate: UInt32 = 0x6772_7570 // 'grup'
+    private let headphonesSource: UInt32 = 0x6864_706E // 'hdpn'
+    private let internalSpeaker: UInt32 = 0x6973_706B // 'ispk'
+    private let externalSpeaker: UInt32 = 0x6573_706B // 'espk'
+    private let internalMic: UInt32 = 0x696D_6963 // 'imic'
+    private let externalMic: UInt32 = 0x656D_6963 // 'emic'
+
+    @Test("built-in jack splits on data source")
+    func builtInOutput() {
+        #expect(DeviceSymbol.wired(
+            transport: builtIn, dataSource: headphonesSource, direction: .output, mac: "macmini"
+        ) == "headphones")
+        #expect(DeviceSymbol.wired(
+            transport: builtIn, dataSource: externalSpeaker, direction: .output, mac: "macmini"
+        ) == "hifispeaker")
+        // Internal speakers — and devices that report nothing — are the Mac.
+        #expect(DeviceSymbol.wired(
+            transport: builtIn, dataSource: internalSpeaker, direction: .output, mac: "macmini"
+        ) == "macmini")
+        #expect(DeviceSymbol.wired(
+            transport: builtIn, dataSource: 0, direction: .output, mac: "macmini"
+        ) == "macmini")
+    }
+
+    @Test("built-in input splits internal vs external mic")
+    func builtInInput() {
+        #expect(DeviceSymbol.wired(
+            transport: builtIn, dataSource: internalMic, direction: .input, mac: "laptopcomputer"
+        ) == "laptopcomputer")
+        #expect(DeviceSymbol.wired(
+            transport: builtIn, dataSource: externalMic, direction: .input, mac: "laptopcomputer"
+        ) == "mic")
+    }
+
+    @Test("wired interfaces are direction-aware")
+    func wiredInterfaces() {
+        #expect(DeviceSymbol.wired(transport: usb, dataSource: 0, direction: .output) == "cable.connector")
+        #expect(DeviceSymbol.wired(transport: usb, dataSource: 0, direction: .input) == "mic")
+        #expect(DeviceSymbol.wired(transport: thunderbolt, dataSource: 0, direction: .output) == "cable.connector")
+    }
+
+    @Test("dedicated transports keep their glyphs")
+    func dedicatedTransports() {
+        #expect(DeviceSymbol.wired(transport: hdmi, dataSource: 0, direction: .output) == "display")
+        #expect(DeviceSymbol.wired(transport: airPlay, dataSource: 0, direction: .output) == "airplay.audio")
+        #expect(DeviceSymbol.wired(transport: virtualTransport, dataSource: 0, direction: .output) == "waveform")
+        #expect(DeviceSymbol.wired(transport: continuityWireless, dataSource: 0, direction: .input) == "iphone")
+        #expect(DeviceSymbol.wired(transport: aggregate, dataSource: 0, direction: .output) == "hifispeaker.2")
+        // Unknown transport: something that plays vs. something that records.
+        #expect(DeviceSymbol.wired(transport: 0, dataSource: 0, direction: .output) == "hifispeaker")
+        #expect(DeviceSymbol.wired(transport: 0, dataSource: 0, direction: .input) == "mic")
+    }
+
+    @Test("AirPods match by name, most specific first")
+    func airPodsByName() {
+        #expect(DeviceSymbol.bluetooth(name: "Misha's AirPods Max", minorClass: 6) == "airpodsmax")
+        #expect(DeviceSymbol.bluetooth(name: "Misha's AirPods Pro", minorClass: 6) == "airpodspro")
+        #expect(DeviceSymbol.bluetooth(name: "Misha's AirPods", minorClass: 6) == "airpods.gen3")
+    }
+
+    @Test("renamed or third-party Bluetooth falls back to minor class")
+    func bluetoothMinorClass() {
+        #expect(DeviceSymbol.bluetooth(name: "WH-1000XM4", minorClass: 6) == "headphones")
+        #expect(DeviceSymbol.bluetooth(name: "JBL Flip 6", minorClass: 5) == "hifispeaker")
+        #expect(DeviceSymbol.bluetooth(name: "Beats Pill", minorClass: 5) == "hifispeaker")
+        #expect(DeviceSymbol.bluetooth(name: "BT Mic", minorClass: 4) == "mic")
+        // Uncategorized — headphones are the likeliest BT audio device.
+        #expect(DeviceSymbol.bluetooth(name: "Mystery Buds", minorClass: 0) == "headphones")
+    }
+
+    @Test("Mac glyph matches marketing names and Intel identifiers")
+    func macModels() {
+        #expect(DeviceSymbol.mac(model: "Mac mini (M1, 2020)") == "macmini")
+        #expect(DeviceSymbol.mac(model: "Macmini8,1") == "macmini")
+        #expect(DeviceSymbol.mac(model: "MacBook Pro (14-inch, Nov 2023)") == "laptopcomputer")
+        #expect(DeviceSymbol.mac(model: "MacBookAir9,1") == "laptopcomputer")
+        #expect(DeviceSymbol.mac(model: "Mac Studio (2022)") == "macstudio")
+        #expect(DeviceSymbol.mac(model: "iMac20,1") == "desktopcomputer")
+        // iMac Pro is an iMac before it is a Pro.
+        #expect(DeviceSymbol.mac(model: "iMacPro1,1") == "desktopcomputer")
+        #expect(DeviceSymbol.mac(model: "MacPro7,1") == "macpro.gen3")
+        #expect(DeviceSymbol.mac(model: "") == "laptopcomputer")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -61,6 +61,9 @@ targets:
       - Fader/Audio/VolumeStore.swift
       - Fader/Audio/DeviceUsageStore.swift
       - Fader/Audio/DevicePriorityStore.swift
+      - Fader/Audio/DeviceSymbol.swift
+      # AudioDirection only; nothing in the tests touches the HAL.
+      - Fader/Audio/HALProperty.swift
     settings:
       base:
         GENERATE_INFOPLIST_FILE: true


### PR DESCRIPTION
Replaces the flat transport→icon switch with a cascade in a new pure `DeviceSymbol`, running from reliable signals to brittle ones; a brittle signal only refines a class, never downgrades it:

- **Built-in** splits on the jack data source: `hdpn` → headphones (the original complaint), external speakers/line → speaker, internal speakers and mic → the Mac's own model glyph (IORegistry product-name, `hw.model` fallback on Intel)
- **Bluetooth** splits on the paired peer's minor device class — a BT speaker is no longer AirPods — with AirPods Pro/Max/regular matched by name on top; renamed devices fall back to the class glyph. Disconnected rows share the same logic instead of a hardcoded headphones icon
- **USB/Thunderbolt & co** stay a cable on the output tab and become a mic on the input tab; virtual devices → waveform, foreign aggregates → device stack, Continuity Capture → iPhone, HDMI/DP → display, AirPlay unchanged

All mapping is hostless-unit-tested; the fourcc literals are validated end-to-end because the tests drive them through the production switch and assert specific glyphs. Verified live: jack shows headphones, Mac mini speakers show a mini, EDIFIER BT speaker shows a speaker, RØDE virtual devices show waveforms.