### PR TITLE
chore(ci): consolidate linting under pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,19 @@ jobs:
       - name: Generate project
         run: xcodegen generate
 
+      # Hook environments (go/node builds) are expensive on macOS runners.
+      - name: Cache pre-commit environments
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # The same suite developers run locally; swiftformat/swiftlint binaries
+      # come sha-verified from install-ci-tools.sh.
       - name: Lint
         run: |
-          swiftformat --lint .
-          swiftlint --strict
+          pipx install pre-commit==4.6.0
+          pre-commit run --all-files --show-diff-on-failure
 
       - name: Build and test
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,9 @@ repos:
       - id: swiftformat
         name: SwiftFormat
         language: system
-        entry: swiftformat --lint
+        # Fixer, not linter: rewrites the files and fails the run, like the
+        # pre-commit-hooks fixers above.
+        entry: swiftformat
         types: [swift]
       - id: swiftlint
         name: SwiftLint

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
 SIGN_FLAGS := CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=$(SIGN_ID)
 endif
 
-.PHONY: gen build test lint format run clean icon og menubar-icon favicon
+.PHONY: gen build test lint run clean icon og menubar-icon favicon
 
 gen:
 	xcodegen generate
@@ -29,12 +29,10 @@ test: gen
 	xcodebuild -project $(XCODEPROJ) -scheme $(SCHEME) -configuration Debug \
 		CODE_SIGNING_ALLOWED=NO test
 
+# All linters and formatters live in .pre-commit-config.yaml; this is the
+# same suite the commit hook and CI run.
 lint:
-	swiftformat --lint .
-	swiftlint --strict
-
-format:
-	swiftformat .
+	pre-commit run --all-files
 
 run: build
 	open "$$(xcodebuild -project $(XCODEPROJ) -scheme $(SCHEME) -configuration Debug \


### PR DESCRIPTION
pre-commit becomes the single owner of linters and formatters:

- the swiftformat hook turns into a fixer (rewrites files like the other pre-commit fixers), so the separate `make format` target is gone
- `make lint` is now an alias for `pre-commit run --all-files`
- CI runs the same suite via pipx-pinned pre-commit, with hook environments cached on the config hash; swiftformat/swiftlint binaries still come sha-verified from `install-ci-tools.sh`

Net effect: CI now also enforces the hygiene hooks (actionlint, gitleaks, markdownlint, whitespace) that previously ran only locally.