### PR TITLE
feat(updates): automatic background updates

### DIFF
--- a/Fader/Audio/HALProperty.swift
+++ b/Fader/Audio/HALProperty.swift
@@ -166,6 +166,13 @@ extension AudioObjectID {
     func readDeviceUID() throws -> String {
         try readString(kAudioDevicePropertyDeviceUID)
     }
+
+    /// True while any process is pulling audio through the device.
+    func readDeviceIsRunningSomewhere() -> Bool {
+        var value: UInt32 = 0
+        try? read(kAudioDevicePropertyDeviceIsRunningSomewhere, into: &value)
+        return value != 0
+    }
 }
 
 /// RAII wrapper for a HAL property listener block dispatched to the main queue.

--- a/Fader/FaderApp.swift
+++ b/Fader/FaderApp.swift
@@ -3,11 +3,14 @@ import SwiftUI
 
 /// Quit must dissolve an active multi-output: the public aggregate would
 /// otherwise outlive the app and haunt Sound settings as the default.
+/// Exception: relaunching into an update keeps the aggregate alive so the
+/// next instance adopts it and audio never reroutes.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     weak static var engine: MixerEngine?
 
     func applicationWillTerminate(_ notification: Notification) {
+        guard !UpdateController.isRelaunchingForUpdate else { return }
         Self.engine?.multiOutput.shutdown()
     }
 }

--- a/Fader/UI/MixerView.swift
+++ b/Fader/UI/MixerView.swift
@@ -57,7 +57,7 @@ struct MixerView: View {
                 appsSection
             }
 
-            if let version = updater.availableVersion {
+            if let version = updater.stagedVersion ?? updater.availableVersion {
                 Divider()
                 UpdateBanner(version: version)
             }

--- a/Fader/UI/StatusItemMenu.swift
+++ b/Fader/UI/StatusItemMenu.swift
@@ -49,15 +49,21 @@ final class StatusItemMenuController: NSObject {
 
         menu.addItem(.separator())
 
-        let checkTitle = updater.availableVersion.map { "Update to \($0)…" } ?? "Check for Updates…"
+        let checkTitle = updater.stagedVersion.map { "Restart to Update to \($0)" }
+            ?? updater.availableVersion.map { "Update to \($0)…" }
+            ?? "Check for Updates…"
         let check = NSMenuItem(title: checkTitle, action: #selector(checkForUpdates), keyEquivalent: "")
         check.target = self
         menu.addItem(check)
 
-        let autoCheck = NSMenuItem(title: "Check Automatically", action: #selector(toggleAutoCheck), keyEquivalent: "")
-        autoCheck.target = self
-        autoCheck.state = updater.automaticallyChecksForUpdates ? .on : .off
-        menu.addItem(autoCheck)
+        let autoUpdate = NSMenuItem(
+            title: "Update Automatically",
+            action: #selector(toggleAutoUpdate),
+            keyEquivalent: ""
+        )
+        autoUpdate.target = self
+        autoUpdate.state = updater.automaticallyUpdates ? .on : .off
+        menu.addItem(autoUpdate)
 
         menu.addItem(.separator())
 
@@ -94,8 +100,8 @@ final class StatusItemMenuController: NSObject {
         updater.checkForUpdates()
     }
 
-    @objc private func toggleAutoCheck() {
-        updater.automaticallyChecksForUpdates.toggle()
+    @objc private func toggleAutoUpdate() {
+        updater.automaticallyUpdates.toggle()
     }
 
     @objc private func visitWebsite() {

--- a/Fader/UI/UpdateBanner.swift
+++ b/Fader/UI/UpdateBanner.swift
@@ -1,47 +1,25 @@
 import SwiftUI
 
-/// Bottom row announcing a found update. A dmg install hands off to
-/// Sparkle's standard flow; a Homebrew install shows the upgrade command
-/// with a copy button instead (see UpdateController for why).
+/// Bottom row announcing an update. A staged download offers a restart into
+/// the new version; an update that is merely available hands off to
+/// Sparkle's standard flow (see UpdateController).
 struct UpdateBanner: View {
     @Environment(UpdateController.self) private var updater
     let version: String
-    @State private var copied = false
 
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "arrow.down.circle.fill")
                 .foregroundStyle(.tint)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Fader \(version) is available")
-                    .font(.system(size: 11, weight: .semibold))
-                if updater.isHomebrewInstall {
-                    Text(UpdateController.homebrewCommand)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-            }
+            Text(updater.stagedVersion != nil
+                ? "Fader \(version) is ready to install"
+                : "Fader \(version) is available")
+                .font(.system(size: 11, weight: .semibold))
             Spacer()
-            if updater.isHomebrewInstall {
-                Button {
-                    UpdateController.copyHomebrewCommand()
-                    copied = true
-                    Task {
-                        try? await Task.sleep(for: .seconds(1.5))
-                        copied = false
-                    }
-                } label: {
-                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                }
-                .controlSize(.small)
-                .help("Copy the upgrade command")
-            } else {
-                Button("Update") {
-                    updater.checkForUpdates()
-                }
-                .controlSize(.small)
+            Button(updater.stagedVersion != nil ? "Restart" : "Update") {
+                updater.checkForUpdates()
             }
+            .controlSize(.small)
         }
         .padding(8)
         .background(.tint.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))

--- a/Fader/UpdateController.swift
+++ b/Fader/UpdateController.swift
@@ -1,16 +1,25 @@
 import AppKit
+import CoreAudio
 import OSLog
 import Sparkle
 
-/// Sparkle wrapper plus the install-channel fork. A dmg install gets the
-/// standard download-install-relaunch flow; a Homebrew install (Caskroom
-/// receipt on disk) only gets told an update exists — Sparkle swapping a
-/// brew-owned bundle would desync the cask receipt and the next
-/// `brew upgrade` would fight the already-new app.
+/// Sparkle wrapper. Background checks are always on; the "Update
+/// Automatically" toggle controls whether a found update is also downloaded
+/// and installed silently. The Homebrew cask declares `auto_updates true`,
+/// so `brew upgrade` leaves the bundle to Sparkle — both install channels
+/// share this one flow.
 ///
-/// Background checks stay silent (gentle reminders): finding an update sets
+/// With auto-update off, background finds stay gentle reminders: they set
 /// `availableVersion`, which lights the popover row and retitles the menu
 /// item; Sparkle's own windows appear only for a user-initiated check.
+/// With auto-update on, the staged update relaunches the app right away —
+/// but only while nobody would notice: the app in the background and no
+/// audio playing (the restart drops process taps for a moment, so a movie
+/// mid-playback would blip to full per-app volume). Otherwise the row and
+/// menu flip to "Restart to Update" and install-on-quit remains the
+/// backstop. An update relaunch skips the multi-output teardown so the
+/// next instance adopts the still-default aggregate — audio keeps flowing
+/// through the restart.
 @MainActor
 @Observable
 final class UpdateController {
@@ -18,20 +27,22 @@ final class UpdateController {
     /// row and the context-menu title.
     private(set) var availableVersion: String?
 
-    let isHomebrewInstall: Bool
+    /// Version downloaded and staged for install. Invoking `checkForUpdates`
+    /// in this state relaunches into it.
+    private(set) var stagedVersion: String?
 
-    static let homebrewCommand = "brew upgrade --cask fader"
+    /// True while the app is terminating to relaunch into a staged update.
+    /// AppDelegate then leaves the multi-output aggregate alive for the next
+    /// instance to adopt instead of dissolving it.
+    private(set) static var isRelaunchingForUpdate = false
 
     static let log = Logger(subsystem: "dev.pantafive.fader", category: "updates")
 
     @ObservationIgnored private var controller: SPUStandardUpdaterController!
     @ObservationIgnored private let bridge = SparkleBridge()
-    /// A menu-initiated check on the brew channel reports through an alert;
-    /// background checks land on the popover row only.
-    @ObservationIgnored private var manualBrewCheck = false
+    @ObservationIgnored private var relaunchHandler: (() -> Void)?
 
     init() {
-        isHomebrewInstall = Self.homebrewOwnsThisBuild()
         controller = SPUStandardUpdaterController(
             startingUpdater: false,
             updaterDelegate: bridge,
@@ -39,51 +50,37 @@ final class UpdateController {
         )
         bridge.owner = self
 
-        // Default-on without Sparkle's first-run permission modal: seed the
-        // user default once. Unlike SUEnableAutomaticChecks in Info.plist,
-        // this stays a preference the menu toggle can flip off.
+        // Checks are forced on every launch: no menu item controls them
+        // anymore, and a stale `false` left by the retired "Check
+        // Automatically" toggle would otherwise kill both auto-update and
+        // the passive banner with no UI to recover. Setting the property
+        // (rather than SUEnableAutomaticChecks in Info.plist) also skips
+        // Sparkle's first-run permission modal. Downloads seed default-on
+        // once and stay a preference the menu toggle can flip off.
         let updater = controller.updater
-        if UserDefaults.standard.object(forKey: "SUEnableAutomaticChecks") == nil {
-            updater.automaticallyChecksForUpdates = true
+        updater.automaticallyChecksForUpdates = true
+        if UserDefaults.standard.object(forKey: "SUAutomaticallyUpdate") == nil {
+            updater.automaticallyDownloadsUpdates = true
         }
         try? updater.start()
     }
 
-    var automaticallyChecksForUpdates: Bool {
-        get { controller.updater.automaticallyChecksForUpdates }
-        set { controller.updater.automaticallyChecksForUpdates = newValue }
+    /// The menu toggle: download and install updates without asking.
+    /// Checking stays on either way — off just means the gentle-reminder
+    /// flow where the user clicks to start Sparkle's interactive update.
+    var automaticallyUpdates: Bool {
+        get { controller.updater.automaticallyDownloadsUpdates }
+        set { controller.updater.automaticallyDownloadsUpdates = newValue }
     }
 
-    /// The Caskroom directory alone is stale evidence: it survives a switch
-    /// to the dmg until `brew uninstall`, which would strand that user on
-    /// manual update prompts forever. Brew names the version subdirectory
-    /// after the cask version (== marketing version), so only a subdirectory
-    /// matching the running build proves brew owns this copy; a dmg update
-    /// past the cask gets the standard Sparkle flow back.
-    private static func homebrewOwnsThisBuild() -> Bool {
-        let version = Bundle.main.shortVersion
-        return ["/opt/homebrew/Caskroom/fader", "/usr/local/Caskroom/fader"]
-            .contains { FileManager.default.fileExists(atPath: "\($0)/\(version)") }
-    }
-
-    /// Menu and popover-row action. Dmg: Sparkle's standard interactive flow.
-    /// Brew: a UI-less probe whose outcome comes back as an alert.
+    /// Menu and popover-row action. With an update staged, relaunch into it;
+    /// otherwise run Sparkle's standard interactive flow.
     func checkForUpdates() {
-        guard isHomebrewInstall else {
-            controller.checkForUpdates(nil)
-            return
-        }
-        if let availableVersion {
-            showBrewAlert(version: availableVersion)
+        if relaunchHandler != nil {
+            relaunch()
         } else {
-            manualBrewCheck = true
-            controller.updater.checkForUpdateInformation()
+            controller.checkForUpdates(nil)
         }
-    }
-
-    static func copyHomebrewCommand() {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(homebrewCommand, forType: .string)
     }
 
     // MARK: - Bridge callbacks (main thread, re-isolated)
@@ -91,49 +88,38 @@ final class UpdateController {
     fileprivate func updateFound(version: String) {
         Self.log.info("update available: \(version, privacy: .public)")
         availableVersion = version
-        if manualBrewCheck {
-            manualBrewCheck = false
-            showBrewAlert(version: version)
-        }
     }
 
-    /// The feed answered and nothing newer is installable.
+    /// The feed answered and nothing newer is installable. A failed check
+    /// (feed unreachable, bad XML) deliberately does NOT clear a previously
+    /// found version — a transient failure is not evidence the update
+    /// disappeared.
     fileprivate func upToDate() {
         Self.log.info("up to date")
         availableVersion = nil
-        guard manualBrewCheck else { return }
-        manualBrewCheck = false
-        let alert = NSAlert()
-        alert.messageText = "You're up to date"
-        alert.informativeText = "Fader \(Bundle.main.shortVersion) is the latest version."
-        NSApp.activate()
-        alert.runModal()
     }
 
-    /// The check itself failed (feed unreachable, bad XML). A previously
-    /// found version stays on the banner — a transient failure is not
-    /// evidence the update disappeared.
-    fileprivate func checkFailed(_ message: String) {
-        Self.log.error("check failed: \(message, privacy: .public)")
-        guard manualBrewCheck else { return }
-        manualBrewCheck = false
-        let alert = NSAlert()
-        alert.messageText = "Couldn't check for updates"
-        alert.informativeText = "The update feed is unreachable. Try again later."
-        NSApp.activate()
-        alert.runModal()
-    }
-
-    private func showBrewAlert(version: String) {
-        let alert = NSAlert()
-        alert.messageText = "Fader \(version) is available"
-        alert.informativeText = "This copy is managed by Homebrew — update from the terminal:\n\(Self.homebrewCommand)"
-        alert.addButton(withTitle: "Copy Command")
-        alert.addButton(withTitle: "Later")
-        NSApp.activate()
-        if alert.runModal() == .alertFirstButtonReturn {
-            Self.copyHomebrewCommand()
+    /// The update is downloaded and staged. Relaunch into it right away
+    /// while nobody is looking — app in the background, output device idle.
+    /// Otherwise surface "Restart to Update" and let the user pick the
+    /// moment; Sparkle installs on quit regardless.
+    fileprivate func updateStaged(version: String, relaunch: @escaping () -> Void) {
+        Self.log.info("update staged: \(version, privacy: .public)")
+        relaunchHandler = relaunch
+        stagedVersion = version
+        if !NSApp.isActive, !Self.audioIsPlaying() {
+            self.relaunch()
         }
+    }
+
+    private func relaunch() {
+        Self.isRelaunchingForUpdate = true
+        relaunchHandler?()
+    }
+
+    private static func audioIsPlaying() -> Bool {
+        guard let device = try? AudioObjectID.readDefaultOutputDevice() else { return false }
+        return device.readDeviceIsRunningSomewhere()
     }
 }
 
@@ -159,14 +145,26 @@ private final class SparkleBridge: NSObject, SPUUpdaterDelegate, @MainActor SPUS
     }
 
     /// Fires for every aborted cycle, including the benign outcomes already
-    /// handled elsewhere — filter those, report the genuine failures.
+    /// handled elsewhere — filter those, log the genuine failures.
     func updater(_: SPUUpdater, didAbortWithError error: Error) {
         let nsError = error as NSError
         if nsError.domain == SUSparkleErrorDomain {
             let benign: [SUError] = [.noUpdateError, .installationCanceledError, .installationAuthorizeLaterError]
             if benign.contains(where: { Int($0.rawValue) == nsError.code }) { return }
         }
-        owner?.checkFailed(error.localizedDescription)
+        UpdateController.log.error("update cycle failed: \(error.localizedDescription, privacy: .public)")
+    }
+
+    /// Fires when the automatic driver has silently downloaded and staged an
+    /// update. Returning true takes over the install reminder; the block
+    /// installs and relaunches without UI and may be invoked again if a
+    /// termination request gets cancelled.
+    func updater(
+        _: SPUUpdater, willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+    ) -> Bool {
+        owner?.updateStaged(version: item.displayVersionString, relaunch: immediateInstallHandler)
+        return true
     }
 
     // MARK: - Gentle reminders

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A macOS menu bar app for audio output switching and per-app volume. Switch the o
 
 <p align="center"><img src="docs/hero.png" alt="Three Fader popovers: multi-output with per-device sliders, the output tab with devices and per-app volume, and the input tab with microphone selection"></p>
 
-No telemetry, no analytics. Per-app volume is processed on-device through Core Audio process taps (an API added in macOS 14.4), so there is no kernel extension and no virtual audio driver to install. Requires macOS 15+ on Apple silicon.
+No telemetry, no kernel extension, no virtual audio driver — the source is open, check for yourself. Requires macOS 15+ on Apple silicon.
 
 ## Install
 
@@ -14,45 +14,20 @@ No telemetry, no analytics. Per-app volume is processed on-device through Core A
 brew install --cask pantafive/tap/fader
 ```
 
-Or download [the latest dmg](https://github.com/pantafive/fader/releases/latest/download/Fader.dmg).
-
-Both channels stay current: the dmg updates itself through Sparkle, the cask through `brew upgrade`.
+Or download [the latest dmg](https://github.com/pantafive/fader/releases/latest/download/Fader.dmg). The app updates itself.
 
 ## Features
 
-### Output devices
-
-Headphones, speakers, displays, and AirPlay targets all appear in the popover, with the active one marked; one click on a row switches to it. Paired-but-disconnected Bluetooth headphones are listed too; clicking one connects it and routes audio there, and you disconnect from the same row.
-
-Drag a device row to set its priority. The order becomes your auto-switch preference: when a higher-priority device connects Fader switches to it, and when the current default disappears Fader falls back to the best-ranked device still present. This stays dormant until you first reorder. Wired devices unused for 30 days collapse into a "Rarely used" group, and you can demote a row manually by dragging it onto the group.
-
-### Several outputs at once
-
-Drag a device row onto the Output section at the top and both devices play together: one movie, two pairs of headphones, one plane. Each device in the group gets its own volume slider; the ✕ removes one, and clicking any device row in the list routes everything back to that single device.
-
-Fader builds this on the same multi-output device you could assemble by hand in Audio MIDI Setup, then removes it when you are done. Two things change while a group plays. The volume keys do nothing, because macOS gives a multi-output device no master volume — the per-device sliders replace them. And per-app faders pause, returning with their saved levels as soon as you are back on one output.
-
-### Per-app volume
-
-Every app that plays sound gets a volume fader and a mute toggle. Volumes persist across launches. An app left at 100% and unmuted is untouched: no tap, no processing, bit-perfect native playback. The tap exists only while a fader sits below full volume or an app is muted.
-
-### Microphone
-
-The microphone tab switches the default input and sets input gain. The gain slider disables itself on devices whose gain is hardware-only, so the control never lies about what it can do. It also shows which apps are using the microphone right now, so you can spot a forgotten recorder. That last part is an indicator only, because Core Audio exposes no per-app input gain.
-
-### Throughout
-
-System output volume and mute stay in sync with the volume keys and Control Center. Scrolling the wheel or trackpad over any slider adjusts it.
+- **Output switching** — headphones, speakers, displays, and AirPlay targets, one click each. Paired Bluetooth headphones connect from the same list.
+- **Auto-switch** — drag rows to rank devices; Fader follows the best one present.
+- **Several outputs at once** — drag a device onto the Output section and both play together, each with its own slider.
+- **Per-app volume** — a fader and mute for every app that plays sound; levels persist. Apps at full volume play untouched, bit-perfect.
+- **Microphone** — switch the default input, set gain, and see which apps are listening.
+- **In sync** — system volume follows the volume keys and Control Center; scrolling over any slider adjusts it.
 
 ## Permissions
 
-Most of Fader needs no permissions. Device switching, system volume, and the entire microphone tab work the moment you install. The one ask is for per-app volume, which uses a Core Audio process tap that macOS gates behind the System Audio Recording permission. Fader requests it only the first time you move an app's fader.
-
-The permission's name sounds broader than what Fader does with it: the tapped audio is re-rendered to your output device with the gain applied and never leaves the Mac.
-
-## Privacy
-
-Fader collects nothing about you: no telemetry, no analytics. The claim is checkable — the source is open, read it.
+Only per-app volume needs one: macOS gates audio taps behind the System Audio Recording permission, requested the first time you move an app's fader. The tapped audio never leaves the Mac.
 
 ## Development
 
@@ -61,17 +36,11 @@ brew install xcodegen swiftlint swiftformat
 make run
 ```
 
-Built in Swift 6 with strict concurrency. The Xcode project is generated by XcodeGen from `project.yml` and is not committed, so edit `project.yml` rather than the `.xcodeproj`. `make` drives local work: `gen`, `build`, `test`, `lint`, `run`, `clean`.
-
-CI lints and tests every push. Pushing a `v*` tag builds, signs, notarizes, and publishes the dmg and a signed Sparkle appcast as a GitHub release. CI pins exact tool versions in `scripts/install-ci-tools.sh` — if a brew-installed swiftlint/swiftformat disagrees with `make lint` results in CI, match those versions.
-
-The real-time audio callback runs on the HAL IO thread. No allocation, locks, Objective-C, or logging is allowed inside it.
+Swift 6, strict concurrency. The Xcode project is generated from `project.yml` — edit that, not the `.xcodeproj`. `make` drives local work: `gen`, `build`, `test`, `lint`, `run`, `clean`. Pushing a `v*` tag builds, signs, notarizes, and publishes a release.
 
 ## Contributing
 
-Bug reports and pull requests are welcome; for anything bigger than a fix, open an issue first. `make test` and `make lint` must pass. Commit messages follow [Conventional Commits](https://www.conventionalcommits.org), imperative mood, English.
-
-Changes to the real-time audio callback get extra scrutiny for the constraints above. Contributions adding telemetry, analytics, or anything that phones home will be declined.
+Bug reports and pull requests are welcome; for anything bigger than a fix, open an issue first. `make test` and `make lint` must pass; commits follow [Conventional Commits](https://www.conventionalcommits.org). The real-time audio callback allows no allocation, locks, Objective-C, or logging — changes there get extra scrutiny. Anything that phones home will be declined.
 
 ## Security
 


### PR DESCRIPTION
## Summary

Updates now install themselves. The brew channel fork is gone — Caskroom detection, terminal-command alerts, the copy button — both install channels run the one Sparkle flow. Background checks are forced on every launch (the retired "Check Automatically" toggle could have persisted `false`, which would dead-end users with no UI to recover); the new "Update Automatically" toggle, default on, controls silent download + install only. With it off, the old flow remains: banner + Update button.

A staged update relaunches the app on the spot only while it's in the background and the output device is idle. Watching a movie or sitting in the popover instead flips the menu and banner to "Restart to Update", with Sparkle's install-on-quit as backstop. The update relaunch skips the multi-output teardown, so the next instance adopts the still-default aggregate and audio never reroutes through the restart.

The README is cut from 836 to 378 words: feature prose to a scannable list, implementation genealogy dropped.

**Required follow-up before the release that ships this:** add `auto_updates true` to the cask in `pantafive/homebrew-tap`. Without it, `brew upgrade` with a lagging cask downgrades the self-updated app.

## Test plan

- [x] `make build`, `make test`, `make lint` green
- [ ] The download → stage → relaunch → adopt chain needs a published appcast newer than the running build — verify on the first real release
