### PR TITLE
feat: run under the app sandbox

### DIFF
--- a/Fader/Resources/Fader.entitlements
+++ b/Fader/Resources/Fader.entitlements
@@ -2,7 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>
 </plist>

--- a/Fader/Resources/Fader.entitlements
+++ b/Fader/Resources/Fader.entitlements
@@ -10,5 +10,10 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>dev.pantafive.fader-spks</string>
+		<string>dev.pantafive.fader-spki</string>
+	</array>
 </dict>
 </plist>

--- a/Fader/Resources/Info.plist
+++ b/Fader/Resources/Info.plist
@@ -30,6 +30,8 @@
 	<string>Fader connects and disconnects your paired Bluetooth headphones.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 pantafive. MIT License.</string>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://github.com/pantafive/fader/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/project.yml
+++ b/project.yml
@@ -52,6 +52,13 @@ targets:
         com.apple.security.device.audio-input: true
         com.apple.security.device.bluetooth: true
         com.apple.security.network.client: true
+        # Sparkle's sandboxed-install path: the app talks to its Installer
+        # XPC service over these mach names. Literal bundle id, not
+        # $(PRODUCT_BUNDLE_IDENTIFIER) — release.yml re-signs with raw
+        # codesign, which does not expand build settings.
+        com.apple.security.temporary-exception.mach-lookup.global-name:
+          - dev.pantafive.fader-spks
+          - dev.pantafive.fader-spki
 
   # Hostless unit tests: pure-logic sources are compiled into the bundle
   # directly, so no app process needs to launch (LSUIElement hosts hang

--- a/project.yml
+++ b/project.yml
@@ -48,7 +48,10 @@ targets:
     entitlements:
       path: Fader/Resources/Fader.entitlements
       properties:
+        com.apple.security.app-sandbox: true
         com.apple.security.device.audio-input: true
+        com.apple.security.device.bluetooth: true
+        com.apple.security.network.client: true
 
   # Hostless unit tests: pure-logic sources are compiled into the bundle
   # directly, so no app process needs to launch (LSUIElement hosts hang


### PR DESCRIPTION
## Summary

Enables the App Sandbox — the prerequisite for a Mac App Store build — with the audio-input, bluetooth, and network.client entitlements, and wires Sparkle for sandboxed installs: `SUEnableInstallerLauncherService` plus the two mach-lookup exceptions for the Installer XPC service (literal bundle ids, since release.yml re-signs with raw codesign and build settings would not expand).

## Verified

- A `--sandbox-probe` launch mode (added and removed within this branch) ran every sandbox-sensitive path inside the container: process taps with private aggregates (per-app volume), the public stacked aggregate (multi-output), default-output read/write, Bluetooth enumeration and connect.
- Manual testing of the sandboxed build: everything works; preferences migrated into the container automatically on first launch.
- Sparkle end-to-end against the live feed: a sandboxed 0.11.0 build with release-style re-signed helpers found the appcast, downloaded the real 0.12.0 dmg, installed through the Installer XPC service and relaunched. Zero sandbox denials in the system log.
- TCC after `tccutil reset All`: taps come up again without re-prompting, and per-app volume confirmed working by ear after the reset.

## Notes

- Minimum macOS stays 15.0 — decided, no doc changes needed.
- First sandboxed release is worth watching end-to-end (CI-signed helpers updating a user install), even though the same sequence passed locally.
