### PR TITLE
fix: taper per-app volume to match the system slider's feel

### DIFF
--- a/Fader/Audio/ProcessTap.swift
+++ b/Fader/Audio/ProcessTap.swift
@@ -13,7 +13,10 @@ import os
 final class ProcessTap: @unchecked Sendable {
     private static let logger = Logger(subsystem: "dev.pantafive.fader", category: "ProcessTap")
 
-    /// Target gain, 0.0...1.0. Read by the RT thread every buffer.
+    /// Slider position, 0.0...1.0. Read by the RT thread every buffer and
+    /// run through `taperedGain` before it reaches the samples — the stored
+    /// value stays linear position so the UI and VolumeStore keep their
+    /// 0...1 semantics.
     private nonisolated(unsafe) var _volume: Float
     /// Mute flag. Read by the RT thread every buffer.
     private nonisolated(unsafe) var _isMuted: Bool
@@ -49,7 +52,7 @@ final class ProcessTap: @unchecked Sendable {
         self.processObjectIDs = processObjectIDs
         _volume = volume
         _isMuted = isMuted
-        _currentGain = volume
+        _currentGain = VolumeTaper.gain(position: volume)
     }
 
     /// Builds the tap → aggregate → IO proc chain on the given output device.
@@ -173,7 +176,7 @@ final class ProcessTap: @unchecked Sendable {
 
         let inputs = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: input))
         let outputs = UnsafeMutableAudioBufferListPointer(output)
-        let targetGain = _volume
+        let targetGain = VolumeTaper.gain(position: _volume)
         var gain = _currentGain
         let ramp = _rampCoefficient
 

--- a/Fader/Audio/VolumeTaper.swift
+++ b/Fader/Audio/VolumeTaper.swift
@@ -1,0 +1,15 @@
+/// Slider-position → amplitude-gain mapping for the per-app process tap.
+///
+/// A linear position→amplitude map crams every audible step into the bottom
+/// of the travel — 0.5 is only −6 dB, still loud, then the last sliver does
+/// everything (the "loud, then nothing" complaint). The system volume slider
+/// tapers, so the per-app tap must too or the two controls feel nothing alike.
+/// Cube law is the standard audio-fader taper: equal slider travel ≈ equal
+/// perceived-loudness change. Kept pure and free of HAL imports so it unit-tests
+/// in the hostless bundle.
+enum VolumeTaper {
+    static func gain(position: Float) -> Float {
+        let p = max(0, min(1, position))
+        return p * p * p
+    }
+}

--- a/Tests/ProcessTapGainTests.swift
+++ b/Tests/ProcessTapGainTests.swift
@@ -1,0 +1,32 @@
+import Testing
+
+@Suite("VolumeTaper.gain")
+struct VolumeTaperTests {
+    @Test("endpoints map to silence and unity")
+    func endpoints() {
+        #expect(VolumeTaper.gain(position: 0) == 0)
+        #expect(VolumeTaper.gain(position: 1) == 1)
+    }
+
+    @Test("clamps out-of-range positions")
+    func clamps() {
+        #expect(VolumeTaper.gain(position: -0.5) == 0)
+        #expect(VolumeTaper.gain(position: 2) == 1)
+    }
+
+    @Test("midpoint sits well below linear −6 dB so the bottom of the travel breathes")
+    func midpointTapered() {
+        // Cube law: 0.5 → 0.125 (≈ −18 dB), not the 0.5 a linear map would give.
+        #expect(VolumeTaper.gain(position: 0.5) == 0.125)
+    }
+
+    @Test("monotonically increasing across the travel")
+    func monotonic() {
+        var previous = VolumeTaper.gain(position: 0)
+        for step in 1 ... 20 {
+            let gain = VolumeTaper.gain(position: Float(step) / 20)
+            #expect(gain > previous)
+            previous = gain
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -103,6 +103,7 @@ targets:
       - Fader/Audio/AudioDevice.swift
       - Fader/Audio/DevicePriorityPolicy.swift
       - Fader/Audio/MultiOutputPolicy.swift
+      - Fader/Audio/VolumeTaper.swift
       # Property wrappers and AudioDirection; nothing in the tests touches
       # a live HAL.
       - Fader/Audio/HALProperty.swift


### PR DESCRIPTION
## Problem

Per-app volume felt wrong: the top half of the slider barely changed loudness, then the bottom sliver did everything. The process tap multiplied samples by the raw slider position — a **linear amplitude** map where 0.5 is only −6 dB. Meanwhile the system/default-device slider rides `VirtualMainVolume`, which Apple already tapers, so the two controls felt nothing alike.

## Fix

Run the slider position through a cube-law audio taper (the standard fader curve: equal travel ≈ equal perceived-loudness change) before it reaches the samples. The stored value stays linear `0...1`, so the UI and `VolumeStore` keep their semantics — only the audible gain changes. The mapping lives in a pure `VolumeTaper` enum so it unit-tests in the hostless bundle.

Scope is just `ProcessTap`. The multi-output per-device sliders already go through `VirtualMainVolume`, so they're untouched.

## Heads-up

Existing saved per-app levels will sound quieter after this change (a stored 0.5 was 0.5 amplitude, now 0.125). Worth re-checking saved levels by ear. The cube curve is a sane default; if it feels too aggressive/soft it's a one-line tune.

## Test

- New `VolumeTaper.gain` tests (endpoints, clamp, tapered midpoint, monotonicity).
- Full suite green (40 tests), lint clean.