### PR TITLE
feat: explain why a fixed-volume device's slider is greyed out

### DIFF
--- a/Fader/UI/ActiveOutputsSection.swift
+++ b/Fader/UI/ActiveOutputsSection.swift
@@ -79,7 +79,10 @@ struct ActiveOutputsSection: View {
     }
 
     /// Mirrors the input tab's rule: a dead slider dims instead of snapping
-    /// back when the device exposes no settable volume.
+    /// back when the device exposes no settable volume — and says why, so the
+    /// greyed-out control reads as "this device runs its own volume" rather
+    /// than a broken slider promising control it doesn't have.
+    @ViewBuilder
     private func slider(for volume: any VolumeControlling) -> some View {
         ControlSlider(
             value: Binding(
@@ -92,6 +95,11 @@ struct ActiveOutputsSection: View {
         )
         .disabled(!volume.canSetVolume)
         .opacity(volume.canSetVolume ? 1.0 : 0.4)
+        if !volume.canSetVolume {
+            Text("Volume is controlled on the device")
+                .font(.system(size: 10))
+                .foregroundStyle(.tertiary)
+        }
     }
 
     private var fallbackRow: some View {

--- a/Fader/UI/MixerView.swift
+++ b/Fader/UI/MixerView.swift
@@ -162,6 +162,11 @@ struct MixerView: View {
             )
             .disabled(!inputVolume.canSetVolume)
             .opacity(inputVolume.canSetVolume ? 1.0 : 0.4)
+            if !inputVolume.canSetVolume {
+                Text("Gain is controlled on the device")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Selecting an output device that exposes no settable volume (HDMI, a monitor, some pro interfaces) already greyed and froze the volume slider — but silently, so a dead slider just looked broken rather than intentional.

## Fix

Add a one-line caption under the disabled slider on both tabs — "Volume is controlled on the device" (output) / "Gain is controlled on the device" (input). The slider was already gated on `canSetVolume`; this gives the greyed-out state a reason, so it reads as honest rather than broken.

## Notes

- No model or HAL changes — reuses the existing `canSetVolume` signal.
- Proactively flagging non-controllable devices in the list rows (before selection) is a sensible follow-up, but it needs a new per-device HAL read and ripples through the test factories — deferred. Best verified against real HDMI hardware.

## Test

Builds clean, lint green. The caption only appears for devices with no settable volume.