### PR TITLE
fix: fade per-app taps to unity before teardown on quit

### DIFF
--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -124,6 +124,32 @@ final class MixerEngine {
         }
     }
 
+    /// Smooths the volume jump when Fader exits. A tap mutes the app's native
+    /// output and re-renders it attenuated, so destroying the tap restores the
+    /// native output at full — an abrupt jump (and click) up from whatever
+    /// level the app was held at. There is no per-app system volume to keep,
+    /// so the app does return to full; ramping each tap to unity first and
+    /// letting the IO proc render the ramp means the native output un-mutes at
+    /// the level it is about to play, a smooth rise instead of a slam. Muted
+    /// taps render silence and can't fade audibly, so they restore as-is.
+    func fadeOutAndStop() {
+        let fading = taps.values.filter { !$0.isMuted && $0.volume < 0.999 }
+        if !fading.isEmpty {
+            for tap in fading {
+                tap.volume = 1.0
+            }
+            // ~5× the 30 ms gain ramp: long enough for the rendered level to
+            // reach unity before teardown un-mutes the native output. Blocking
+            // is fine here — this only runs from applicationWillTerminate, and
+            // the IO proc rendering the ramp lives on its own queue.
+            Thread.sleep(forTimeInterval: 0.15)
+        }
+        for tap in taps.values {
+            tap.invalidate()
+        }
+        taps.removeAll()
+    }
+
     // MARK: - Private
 
     private func observeApps() {

--- a/Fader/FaderApp.swift
+++ b/Fader/FaderApp.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         guard !UpdateController.isRelaunchingForUpdate else { return }
+        Self.engine?.fadeOutAndStop()
         Self.engine?.multiOutput.shutdown()
     }
 }


### PR DESCRIPTION
## Problem

With an app held at a low per-app volume, quitting Fader made it jump back to full volume with an audible click. A per-app tap mutes the app's native output and re-renders it attenuated; destroying the tap on quit un-mutes the native output instantly at full, so the level slams up from wherever the app was held.

There is no per-app volume stored in the system — the tap *is* the volume — so the app legitimately returns to full when Fader exits. The fix is to make that return smooth instead of abrupt.

## Fix

In `applicationWillTerminate`, ramp each live tap to unity and let the IO proc render the ramp (~150 ms, ≈5× the existing 30 ms gain ramp) before tearing the taps down. The native output then un-mutes at the level it's about to play — a smooth rise, no click. The brief blocking wait only runs on quit.

Scope is deliberately just the quit path. In-use tap rebuilds (browser spawning a media child, output-device switch) are left as-is — applying a fade there would swell up-then-down on every rebuild, worse than the current quick handoff.

Muted taps render silence and can't fade audibly, so they restore as-is.

## Test

Builds clean, full suite green, lint clean. The smoothness is audible-only — worth an ear check: hold an app low, quit Fader, listen for the click/slam.