### PR TITLE
feat: per-app output routing with per-device volume

### DIFF
--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -29,6 +29,9 @@ final class MixerEngine {
     private(set) var volumes: [String: AppVolume] = [:]
 
     @ObservationIgnored private var taps: [String: ProcessTap] = [:]
+    /// One volume control per pinned-and-present device, keyed by UID — each
+    /// routed output gets its own slider, like multi-output members.
+    @ObservationIgnored private var routeVolumes: [String: DeviceVolumeController] = [:]
     @ObservationIgnored private let store = VolumeStore()
     @ObservationIgnored private var deviceListener: HALListener?
     @ObservationIgnored private var saveTask: Task<Void, Never>?
@@ -48,7 +51,7 @@ final class MixerEngine {
         // Rebuild taps when the default output device changes — each aggregate
         // is pinned to a concrete device UID.
         deviceListener = AudioObjectID.system.listen(kAudioHardwarePropertyDefaultOutputDevice) {
-            Task { @MainActor [weak self] in self?.rebuildAllTaps() }
+            Task { @MainActor [weak self] in self?.reconcileTapRouting() }
         }
 
         observeApps()
@@ -174,6 +177,7 @@ final class MixerEngine {
                 guard let self else { return }
                 self.refreshBluetoothSoon()
                 self.multiOutput.handleDevicesChanged(present: self.deviceMonitor.devices)
+                self.reconcileTapRouting()
                 self.observeDevices()
             }
         }
@@ -236,6 +240,22 @@ final class MixerEngine {
             guard taps[bundleID] == nil, let app = running[bundleID] else { continue }
             createTap(for: app, entry: entry)
         }
+        syncRouteVolumes()
+    }
+
+    /// Keeps one DeviceVolumeController alive per pinned-and-present device,
+    /// dropping controllers for devices no longer pinned or gone from the HAL.
+    /// Rebuilt whenever routes or the device list change.
+    private func syncRouteVolumes() {
+        let pinned = Set(volumes.values.flatMap(\.outputDeviceUIDs))
+            .filter { uid in deviceMonitor.devices.contains { $0.uid == uid } }
+        for uid in routeVolumes.keys where !pinned.contains(uid) {
+            routeVolumes[uid] = nil
+        }
+        for uid in pinned where routeVolumes[uid] == nil {
+            guard let device = deviceMonitor.devices.first(where: { $0.uid == uid }) else { continue }
+            routeVolumes[uid] = DeviceVolumeController(deviceID: device.id)
+        }
     }
 
     private func createTap(for app: AudioApp, entry: AppVolume) {
@@ -245,18 +265,26 @@ final class MixerEngine {
         // Saved volumes survive and re-apply once multi-output dissolves.
         guard !multiOutput.isActive else { return }
 
-        let outputUID: String
+        let outputUIDs: [String]
         do {
-            outputUID = try AudioObjectID.readDefaultOutputDevice().readDeviceUID()
+            outputUIDs = try resolvedOutputUIDs(for: entry)
         } catch {
             // Transient device churn (output switching), not a permission issue.
             Self.logger.error("Default device read failed: \(error.localizedDescription)")
             return
         }
 
+        // A routed app's loudness lives on its devices' own volume controls
+        // (one slider per pinned device), so its tap renders transparent — the
+        // app-level gain and mute apply only when it follows the default.
+        let routed = !entry.outputDeviceUIDs.isEmpty
         do {
-            let tap = ProcessTap(processObjectIDs: app.objectIDs, volume: entry.volume, isMuted: entry.isMuted)
-            try tap.activate(outputDeviceUID: outputUID)
+            let tap = ProcessTap(
+                processObjectIDs: app.objectIDs,
+                volume: routed ? 1.0 : entry.volume,
+                isMuted: routed ? false : entry.isMuted
+            )
+            try tap.activate(outputDeviceUIDs: outputUIDs)
             taps[app.bundleID] = tap
             needsAudioCapturePermission = false
         } catch {
@@ -266,12 +294,95 @@ final class MixerEngine {
         }
     }
 
-    private func rebuildAllTaps() {
-        let bundleIDs = Array(taps.keys)
-        for bundleID in bundleIDs {
-            taps[bundleID]?.invalidate()
+    /// The UID an app's tap should play through: its pinned route when that
+    /// device is present, otherwise the system default. A pinned-but-absent
+    /// device falls back to the default so the app stays audible until it
+    /// returns — the stored route survives for when it does.
+    private func resolvedOutputUIDs(for entry: AppVolume) throws -> [String] {
+        let present = entry.outputDeviceUIDs.compactMap { uid in
+            deviceMonitor.devices.first { $0.uid == uid }
+        }
+        // Clock leads: a Bluetooth clock drifts, so a wired/built-in member is
+        // preferred to drive the aggregate, mirroring multi-output.
+        guard let clock = MultiOutputPolicy.clock(among: present) else {
+            return try [AudioObjectID.readDefaultOutputDevice().readDeviceUID()]
+        }
+        return [clock.uid] + present.map(\.uid).filter { $0 != clock.uid }
+    }
+
+    /// Rebuilds only the taps whose target device no longer matches where they
+    /// play: a default switch moves the follow-default taps, a routed device
+    /// appearing or vanishing moves the pinned ones, and unrelated apps are left
+    /// untouched so they don't blip. One rule covers all three.
+    private func reconcileTapRouting() {
+        for (bundleID, tap) in taps {
+            guard let entry = volumes[bundleID],
+                  let desired = try? resolvedOutputUIDs(for: entry),
+                  desired != tap.activatedOutputUIDs else { continue }
+            tap.invalidate()
             taps[bundleID] = nil
         }
         syncTaps()
+    }
+
+    private func rebuildTap(for app: AudioApp, entry: AppVolume) {
+        if let tap = taps.removeValue(forKey: app.bundleID) {
+            tap.invalidate()
+        }
+        if !entry.isNeutral {
+            createTap(for: app, entry: entry)
+        }
+        syncRouteVolumes()
+    }
+}
+
+// MARK: - Per-app routing
+
+extension MixerEngine {
+    /// The UIDs an app is pinned to, present or not — drives the route chips.
+    func routeUIDs(for app: AudioApp) -> [String] {
+        volumes[app.bundleID]?.outputDeviceUIDs ?? []
+    }
+
+    /// Name of a pinned device by UID, when it is still present.
+    func routeDeviceName(forUID uid: String) -> String? {
+        deviceMonitor.devices.first { $0.uid == uid }?.name
+    }
+
+    /// The volume control backing a pinned device's own slider, if present.
+    func routeVolume(forUID uid: String) -> (any VolumeControlling)? {
+        routeVolumes[uid]
+    }
+
+    /// Pins an app's audio to another output device, on top of any already
+    /// pinned. Routing forces a tap even at unity gain (the tap IS the route),
+    /// so the tap is rebuilt to fan its aggregate out to the new device set.
+    func route(_ app: AudioApp, to device: AudioDevice) {
+        var entry = volumes[app.bundleID] ?? AppVolume()
+        guard !entry.outputDeviceUIDs.contains(device.uid) else { return }
+        entry.outputDeviceUIDs.append(device.uid)
+        volumes[app.bundleID] = entry
+        scheduleSave()
+        rebuildTap(for: app, entry: entry)
+    }
+
+    /// Drops one pinned device. The app keeps playing on whatever remains, and
+    /// returns to the default once the last pin is gone.
+    func unroute(_ app: AudioApp, from uid: String) {
+        guard var entry = volumes[app.bundleID], entry.outputDeviceUIDs.contains(uid) else { return }
+        entry.outputDeviceUIDs.removeAll { $0 == uid }
+        volumes[app.bundleID] = entry.isNeutral ? nil : entry
+        scheduleSave()
+        rebuildTap(for: app, entry: entry)
+    }
+
+    /// Clears every route, returning the app to the default output. Drops the
+    /// tap when nothing else (volume or mute) keeps the app non-neutral.
+    func clearRoute(for app: AudioApp) {
+        guard var entry = volumes[app.bundleID], !entry.outputDeviceUIDs.isEmpty else { return }
+        entry.outputDeviceUIDs.removeAll()
+        volumes[app.bundleID] = entry.isNeutral ? nil : entry
+        scheduleSave()
+        rebuildTap(for: app, entry: entry)
     }
 }

--- a/Fader/Audio/ProcessTap.swift
+++ b/Fader/Audio/ProcessTap.swift
@@ -38,6 +38,12 @@ final class ProcessTap: @unchecked Sendable {
 
     let processObjectIDs: [AudioObjectID]
 
+    /// UIDs of the output devices this tap's aggregate fans out to, clock
+    /// first. The aggregate pins them at activation, so a route or default
+    /// change is honoured by rebuilding the tap, not mutating it — this records
+    /// the current pins.
+    private(set) var activatedOutputUIDs: [String] = []
+
     var volume: Float {
         get { _volume }
         set { _volume = max(0, min(1, newValue)) }
@@ -55,10 +61,14 @@ final class ProcessTap: @unchecked Sendable {
         _currentGain = VolumeTaper.gain(position: volume)
     }
 
-    /// Builds the tap → aggregate → IO proc chain on the given output device.
+    /// Builds the tap → aggregate → IO proc chain. The first UID is the clock
+    /// (and main) sub-device; any others stack on with drift compensation, so
+    /// the app fans out to several devices at once.
     @MainActor
-    func activate(outputDeviceUID: String) throws {
+    func activate(outputDeviceUIDs: [String]) throws {
         guard !aggregateID.isValid else { return }
+        guard let clockUID = outputDeviceUIDs.first else { return }
+        activatedOutputUIDs = outputDeviceUIDs
 
         let description = CATapDescription(stereoMixdownOfProcesses: processObjectIDs)
         description.uuid = UUID()
@@ -70,20 +80,25 @@ final class ProcessTap: @unchecked Sendable {
         try checked(AudioHardwareCreateProcessTap(description, &tap), "create process tap")
         tapID = tap
 
-        let aggregateDescription: [String: Any] = [
+        var aggregateDescription: [String: Any] = [
             // The plumbing prefix keeps it out of AudioDeviceMonitor's list.
             kAudioAggregateDeviceNameKey: "\(AudioDevice.plumbingNamePrefix) aggregate #\(processObjectIDs.first ?? 0)",
             kAudioAggregateDeviceUIDKey: UUID().uuidString,
-            kAudioAggregateDeviceMainSubDeviceKey: outputDeviceUID,
-            kAudioAggregateDeviceClockDeviceKey: outputDeviceUID,
+            kAudioAggregateDeviceMainSubDeviceKey: clockUID,
+            kAudioAggregateDeviceClockDeviceKey: clockUID,
             kAudioAggregateDeviceIsPrivateKey: true,
             kAudioAggregateDeviceTapAutoStartKey: true,
-            kAudioAggregateDeviceSubDeviceListKey: [[kAudioSubDeviceUIDKey: outputDeviceUID]],
+            kAudioAggregateDeviceSubDeviceListKey: outputDeviceUIDs.map {
+                [kAudioSubDeviceUIDKey: $0, kAudioSubDeviceDriftCompensationKey: $0 != clockUID]
+            },
             kAudioAggregateDeviceTapListKey: [[
                 kAudioSubTapUIDKey: description.uuid.uuidString,
                 kAudioSubTapDriftCompensationKey: true,
             ]],
         ]
+        if outputDeviceUIDs.count > 1 {
+            aggregateDescription[kAudioAggregateDeviceIsStackedKey] = true
+        }
 
         var aggregate = AudioObjectID.unknown
         try checked(AudioHardwareCreateAggregateDevice(aggregateDescription as CFDictionary, &aggregate),

--- a/Fader/Audio/VolumeStore.swift
+++ b/Fader/Audio/VolumeStore.swift
@@ -4,9 +4,47 @@ import Foundation
 struct AppVolume: Codable, Equatable {
     var volume: Float = 1.0
     var isMuted: Bool = false
+    /// UIDs of the output devices this app is pinned to, clock first; empty to
+    /// follow the system default. A pinned app always needs a tap (the tap IS
+    /// the route), so a non-empty list is never neutral even at unity gain.
+    var outputDeviceUIDs: [String] = []
 
-    /// Unity gain and unmuted — the app's audio path does not need a tap.
-    var isNeutral: Bool { volume == 1.0 && !isMuted }
+    /// Unity gain, unmuted, and following the default output — the app's audio
+    /// path does not need a tap.
+    var isNeutral: Bool { volume == 1.0 && !isMuted && outputDeviceUIDs.isEmpty }
+
+    init(volume: Float = 1.0, isMuted: Bool = false, outputDeviceUIDs: [String] = []) {
+        self.volume = volume
+        self.isMuted = isMuted
+        self.outputDeviceUIDs = outputDeviceUIDs
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case volume, isMuted, outputDeviceUIDs, outputDeviceUID
+    }
+
+    /// Tolerates the pre-multi-route blob, which stored a single
+    /// `outputDeviceUID` — without this the whole dictionary would fail to
+    /// decode and every saved volume would be lost on upgrade.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        volume = try container.decodeIfPresent(Float.self, forKey: .volume) ?? 1.0
+        isMuted = try container.decodeIfPresent(Bool.self, forKey: .isMuted) ?? false
+        if let list = try container.decodeIfPresent([String].self, forKey: .outputDeviceUIDs) {
+            outputDeviceUIDs = list
+        } else if let legacy = try container.decodeIfPresent(String.self, forKey: .outputDeviceUID) {
+            outputDeviceUIDs = [legacy]
+        } else {
+            outputDeviceUIDs = []
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(volume, forKey: .volume)
+        try container.encode(isMuted, forKey: .isMuted)
+        try container.encode(outputDeviceUIDs, forKey: .outputDeviceUIDs)
+    }
 }
 
 /// Persists app volumes as a single JSON blob in UserDefaults.

--- a/Fader/UI/AppRowView.swift
+++ b/Fader/UI/AppRowView.swift
@@ -1,16 +1,37 @@
 import SwiftUI
 
+/// Collects each app row's frame in global space so a device dragged out of
+/// the list can be dropped onto a row to route that app's audio there. Keyed
+/// by bundle identifier; last writer wins on the rare key collision.
+struct AppRouteZonePreferenceKey: PreferenceKey {
+    static let defaultValue: [String: CGRect] = [:]
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
 /// One mixer row: app icon, name, volume percentage, and a ControlSlider.
 struct AppRowView: View {
-    /// Vertical rhythm of the apps list (name line + slider + spacing);
+    /// Vertical rhythm of a plain (unrouted) row — name line plus its slider;
     /// MixerView's scroll-frame height relies on it, like DeviceRowView's.
-    static let rowHeight: CGFloat = 57
+    static let rowHeight: CGFloat = 53
+    /// A routed row instead sizes to its name line plus the device card: this
+    /// header part, then one `routeDeviceHeight` per pinned device.
+    static let routedHeaderHeight: CGFloat = 40
+    static let routeDeviceHeight: CGFloat = 48
 
     @Environment(MixerEngine.self) private var engine
     let app: AudioApp
+    /// True while a device is dragged over this row — highlights the drop.
+    var isRouteTarget: Bool = false
 
     var body: some View {
         let entry = engine.volume(for: app)
+        let routeUIDs = engine.routeUIDs(for: app)
+        // A paused (silent, non-neutral) row dims so it reads apart from live
+        // ones — but the pinned-device card stays bright: on a paused app its
+        // outputs are exactly what the user wants to see.
+        let pausedDim: Double = app.isPlaying ? 1.0 : 0.5
 
         VStack(alignment: .leading, spacing: 5) {
             HStack(spacing: 6) {
@@ -21,31 +42,111 @@ struct AppRowView: View {
                     .font(.system(size: 12, weight: .medium))
                     .lineLimit(1)
                 Spacer()
-                Text(entry.isMuted ? "muted" : "\(Int(entry.volume * 100))%")
-                    .font(.system(size: 11, weight: .regular, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .contentTransition(.numericText())
+                // A routed app's loudness lives on its per-device sliders, so
+                // the app-level percentage gives way to them.
+                if routeUIDs.isEmpty {
+                    Text(entry.isMuted ? "muted" : "\(Int(entry.volume * 100))%")
+                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .contentTransition(.numericText())
+                }
             }
+            .opacity(pausedDim)
 
-            ControlSlider(
-                value: Binding(
-                    get: { entry.volume },
-                    set: { engine.setVolume($0, for: app) }
-                ),
-                icon: sliderIcon(entry),
-                iconDimmed: entry.isMuted,
-                onIconTap: { engine.toggleMute(for: app) }
-            )
-            .opacity(entry.isMuted ? 0.55 : 1.0)
+            if routeUIDs.isEmpty {
+                ControlSlider(
+                    value: Binding(
+                        get: { entry.volume },
+                        set: { engine.setVolume($0, for: app) }
+                    ),
+                    icon: sliderIcon(entry),
+                    iconDimmed: entry.isMuted,
+                    onIconTap: { engine.toggleMute(for: app) }
+                )
+                .opacity((entry.isMuted ? 0.55 : 1.0) * pausedDim)
+            } else {
+                routeCard(routeUIDs)
+            }
         }
-        // Rows shown only for their saved volume (nothing audible right now)
-        // dim, so live and idle apps read apart at a glance. Still fully
-        // interactive — the knob that made an app quiet must stay reachable.
-        .opacity(app.isPlaying ? 1.0 : 0.5)
+        .padding(.horizontal, 6)
+        .background(
+            isRouteTarget ? AnyShapeStyle(Color.accentColor.opacity(0.15)) : AnyShapeStyle(.clear),
+            in: RoundedRectangle(cornerRadius: 8)
+        )
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: AppRouteZonePreferenceKey.self,
+                    value: [app.bundleID: proxy.frame(in: .global)]
+                )
+            }
+        )
         .animation(.easeOut(duration: 0.2), value: app.isPlaying)
         .contextMenu {
             Button("Reset to 100%") { engine.reset(app) }
+            if !engine.routeUIDs(for: app).isEmpty {
+                Button("Play on default output") { engine.clearRoute(for: app) }
+            }
         }
+    }
+
+    /// The pinned devices, each its own row with its own volume slider,
+    /// grouped in an accent card that ties them to this app.
+    private func routeCard(_ uids: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(uids, id: \.self) { uid in
+                routeDeviceRow(uid)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.accentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    /// One pinned device: name with a tap-to-clear ✕, then its own volume
+    /// slider. An absent device reads "Unavailable" and shows no slider — the
+    /// pin is kept and re-applies once it returns.
+    private func routeDeviceRow(_ uid: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.turn.down.right")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(engine.routeDeviceName(forUID: uid) ?? "Unavailable")
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+                Button {
+                    engine.unroute(app, from: uid)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help("Stop playing to this device")
+            }
+            .foregroundStyle(Color.accentColor)
+
+            if let volume = engine.routeVolume(forUID: uid) {
+                deviceSlider(volume)
+            }
+        }
+    }
+
+    /// A device's own volume slider — same control the multi-output members
+    /// use; a device with no settable volume shows a dimmed, frozen slider.
+    private func deviceSlider(_ volume: any VolumeControlling) -> some View {
+        ControlSlider(
+            value: Binding(
+                get: { volume.volume },
+                set: { volume.setVolume($0) }
+            ),
+            icon: volume.isMuted ? "speaker.slash.fill" : "speaker.wave.3.fill",
+            iconDimmed: volume.isMuted,
+            onIconTap: volume.canMute ? { volume.toggleMute() } : nil
+        )
+        .disabled(!volume.canSetVolume)
+        .opacity(volume.canSetVolume ? 1.0 : 0.4)
     }
 
     private func sliderIcon(_ entry: AppVolume) -> String {

--- a/Fader/UI/DeviceListSection.swift
+++ b/Fader/UI/DeviceListSection.swift
@@ -13,11 +13,17 @@ struct DeviceListSection: View {
     var pairZone: CGRect = .null
     var onPairHover: ((Bool) -> Void)?
     var onPair: ((AudioDevice) -> Void)?
+    /// App rows (bundleID → global frame) a dragged device can drop onto to
+    /// route that app's audio there. Empty disables routing.
+    var appZones: [String: CGRect] = [:]
+    var onRouteHover: ((String?) -> Void)?
+    var onRoute: ((String, AudioDevice) -> Void)?
 
     /// Drag state: which row is in flight and how far it travelled.
     @State private var draggedUID: String?
     @State private var dragOffset: CGFloat = 0
     @State private var isOverPairZone = false
+    @State private var isOverRouteZone = false
 
     static let rowSpacing: CGFloat = 2
     /// Distance between row centers — the unit of drag math.
@@ -57,7 +63,7 @@ struct DeviceListSection: View {
     /// devices that can actually be demoted. While the cursor hovers the
     /// pair zone the row stays put — the drag is aiming elsewhere.
     private func dragTarget(from: Int, main: [AudioDevice]) -> Int {
-        guard !isOverPairZone else { return from }
+        guard !isOverPairZone, !isOverRouteZone else { return from }
         let delta = Int((dragOffset / Self.rowPitch).rounded())
         let canDemote = !main[from].isBluetooth && monitor.defaultDeviceID != main[from].id
         return min(max(from + delta, 0), canDemote ? main.count : main.count - 1)
@@ -91,18 +97,30 @@ struct DeviceListSection: View {
                 isOverPairZone = over
                 onPairHover?(over)
             }
+            // Pairing wins over routing where the zones could ever overlap.
+            let routeHit = over ? nil : appZones.first { $0.value.contains(location) }?.key
+            if (routeHit != nil) != isOverRouteZone {
+                isOverRouteZone = routeHit != nil
+            }
+            onRouteHover?(routeHit)
         case let .finished(location):
             defer {
                 if isOverPairZone {
                     isOverPairZone = false
                     onPairHover?(false)
                 }
+                isOverRouteZone = false
+                onRouteHover?(nil)
                 draggedUID = nil
                 dragOffset = 0
             }
             guard main.indices.contains(index) else { return }
             if let onPair, pairZone.contains(location) {
                 onPair(main[index])
+                return
+            }
+            if let onRoute, let bundleID = appZones.first(where: { $0.value.contains(location) })?.key {
+                onRoute(bundleID, main[index])
                 return
             }
             let target = dragTarget(from: index, main: main)

--- a/Fader/UI/DeviceRowView.swift
+++ b/Fader/UI/DeviceRowView.swift
@@ -100,6 +100,9 @@ struct DeviceRowView: View {
             monitor.setDefault(device)
         }
         .gesture(reorderGesture)
+        // A reorderable row is grabbable — say so with the pointer, the only
+        // hint the drag gestures (reorder, pair, route) get before they start.
+        .pointerStyle(reorder != nil ? (isDraggingRow ? .grabActive : .grabIdle) : nil)
     }
 
     private var reorderGesture: some Gesture {

--- a/Fader/UI/MixerView.swift
+++ b/Fader/UI/MixerView.swift
@@ -13,6 +13,10 @@ struct MixerView: View {
     /// target for pairing a second output device.
     @State private var pairZoneFrame: CGRect = .null
     @State private var isPairTarget = false
+    /// App-row frames (bundleID → global) and the row a device is hovering —
+    /// the drop targets for routing an app to a non-default output device.
+    @State private var appRouteZones: [String: CGRect] = [:]
+    @State private var routeTargetBundleID: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -28,10 +32,17 @@ struct MixerView: View {
                 if engine.isStarted, hasOutputListRows {
                     DeviceListSection(
                         monitor: engine.deviceMonitor,
-                        excludedUIDs: activeOutputUIDs,
+                        excludedUIDs: activeOutputUIDs.union(routedOutputUIDs),
                         pairZone: pairZoneFrame,
                         onPairHover: { isPairTarget = $0 },
-                        onPair: { engine.pair($0) }
+                        onPair: { engine.pair($0) },
+                        appZones: appRouteZones,
+                        onRouteHover: { routeTargetBundleID = $0 },
+                        onRoute: { bundleID, device in
+                            if let app = engine.processMonitor.apps.first(where: { $0.bundleID == bundleID }) {
+                                engine.route(app, to: device)
+                            }
+                        }
                     )
                 }
             } else {
@@ -65,6 +76,7 @@ struct MixerView: View {
         .padding(12)
         .frame(width: 320)
         .task { engine.bluetooth.refresh() }
+        .onPreferenceChange(AppRouteZonePreferenceKey.self) { appRouteZones = $0 }
     }
 
     /// Active outputs live in the zone above the list, not in the list:
@@ -77,8 +89,16 @@ struct MixerView: View {
         return Set(monitor.devices.filter { $0.id == monitor.defaultDeviceID }.map(\.uid))
     }
 
+    /// Devices a running app has pinned its audio to live on that app's row,
+    /// not in the picker — like paired outputs, a routed device leaves the
+    /// list so it reads as owned, not as another switchable default.
+    private var routedOutputUIDs: Set<String> {
+        Set(engine.processMonitor.apps.flatMap { engine.routeUIDs(for: $0) })
+    }
+
     private var hasOutputListRows: Bool {
-        engine.deviceMonitor.devices.contains { !activeOutputUIDs.contains($0.uid) }
+        let excluded = activeOutputUIDs.union(routedOutputUIDs)
+        return engine.deviceMonitor.devices.contains { !excluded.contains($0.uid) }
     }
 
     /// Full-width segmented switch — the native compact picker is a fiddly
@@ -124,16 +144,23 @@ struct MixerView: View {
 
     private var bluetoothSection: some View {
         VStack(alignment: .leading, spacing: DeviceListSection.rowSpacing) {
-            Text("Bluetooth")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.tertiary)
-                .textCase(.uppercase)
-                .padding(.horizontal, 8)
+            sectionLabel("Bluetooth")
             ForEach(disconnectedBluetooth) { device in
                 BluetoothRowView(device: device)
             }
         }
         .padding(.horizontal, -8)
+    }
+
+    /// Uppercase caps that label a free-floating list section (Bluetooth,
+    /// Apps). The output/input volume groups keep their bolder box titles —
+    /// a heading for a control group reads differently from a list label.
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .textCase(.uppercase)
+            .padding(.horizontal, 8)
     }
 
     private var inputVolumeSection: some View {
@@ -191,15 +218,30 @@ struct MixerView: View {
             // MenuBarExtra windows size to the content's ideal height, and a
             // ScrollView's ideal height is zero — give it an explicit one.
             let apps = mixerApps
-            ScrollView {
-                VStack(spacing: 12) {
-                    ForEach(apps) { app in
-                        AppRowView(app: app)
-                    }
-                }
-                .padding(.vertical, 2)
+            // Cap the viewport at six rows; routed rows carry an extra route
+            // line, so size to the visible slice's real heights, not a flat
+            // per-row constant.
+            let visible = apps.prefix(6)
+            // A routed app is taller — its header plus one slider per device —
+            // so sum each app's real height instead of a flat per-row constant.
+            let listHeight = visible.reduce(CGFloat(0)) { total, app in
+                let pins = engine.routeUIDs(for: app).count
+                return total + (pins == 0
+                    ? AppRowView.rowHeight
+                    : AppRowView.routedHeaderHeight + CGFloat(pins) * AppRowView.routeDeviceHeight)
             }
-            .frame(height: min(CGFloat(apps.count), 6) * AppRowView.rowHeight)
+            VStack(alignment: .leading, spacing: 6) {
+                sectionLabel("Apps")
+                ScrollView {
+                    VStack(spacing: 8) {
+                        ForEach(apps) { app in
+                            AppRowView(app: app, isRouteTarget: routeTargetBundleID == app.bundleID)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+                .frame(height: listHeight)
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Or download [the latest dmg](https://github.com/pantafive/fader/releases/latest/
 - **Auto-switch** — drag rows to rank devices; Fader follows the best one present.
 - **Several outputs at once** — drag a device onto the Output section and both play together, each with its own slider.
 - **Per-app volume** — a fader and mute for every app that plays sound; levels persist. Apps at full volume play untouched, bit-perfect.
+- **Per-app output** — drag one or more devices onto an app to play it through exactly those outputs, each with its own volume; everything else stays on your main output.
 - **Microphone** — switch the default input, set gain, and see which apps are listening.
 - **In sync** — system volume follows the volume keys and Control Center; scrolling over any slider adjusts it.
 

--- a/Tests/VolumeStoreTests.swift
+++ b/Tests/VolumeStoreTests.swift
@@ -48,4 +48,30 @@ struct AppVolumeTests {
         #expect(!AppVolume(volume: 0.99, isMuted: false).isNeutral)
         #expect(!AppVolume(volume: 1.0, isMuted: true).isNeutral)
     }
+
+    /// A route forces a tap even at unity gain, so a routed-at-unity entry must
+    /// not read as neutral — otherwise VolumeStore.save drops it and the route
+    /// is silently lost on the next write.
+    @Test("a route keeps a unity entry non-neutral")
+    func routedIsNotNeutral() {
+        #expect(!AppVolume(volume: 1.0, isMuted: false, outputDeviceUIDs: ["dev-uid"]).isNeutral)
+    }
+
+    @Test("routed devices survive a save round-trip, order kept")
+    func routedRoundTrips() throws {
+        let defaults = try #require(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let store = VolumeStore(defaults: defaults)
+        store.save(["com.app": AppVolume(volume: 1.0, isMuted: false, outputDeviceUIDs: ["dev-a", "dev-b"])])
+        #expect(store.load()["com.app"]?.outputDeviceUIDs == ["dev-a", "dev-b"])
+    }
+
+    /// The pre-multi-route blob stored a single `outputDeviceUID`; decoding must
+    /// fold it into the list rather than throw and lose every saved volume.
+    @Test("a legacy single-route entry decodes into the list")
+    func legacyRouteDecodes() throws {
+        let json = #"{"com.app":{"volume":1,"isMuted":false,"outputDeviceUID":"dev-uid"}}"#
+        let decoded = try JSONDecoder().decode([String: AppVolume].self, from: Data(json.utf8))
+        #expect(decoded["com.app"]?.outputDeviceUIDs == ["dev-uid"])
+    }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -544,6 +544,32 @@
     font-weight: 600;
   }
   .mock .app .pct { margin-left: auto; color: var(--muted); font-weight: 400; font-variant-numeric: tabular-nums; }
+  /* A pinned app drops its own slider for an accent card: each device it
+     plays to, with its own volume slider — like the real popover. */
+  .mock .app-routes {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: -2px 4px 12px;
+    padding: 8px;
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
+    border-radius: 10px;
+  }
+  .mock .route-dev { display: flex; flex-direction: column; gap: 6px; }
+  .mock .route-head {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--accent);
+  }
+  .mock .route-head .x { margin-left: auto; cursor: pointer; opacity: 0.75; }
+  .mock .route-head .x:hover { opacity: 1; }
+  .mock .slider.route-slider { --fill: var(--accent); margin-bottom: 0; }
+  .mock .slider.route-slider span { color: rgba(255, 255, 255, 0.9); }
+  /* A device dragged over an app row highlights it as the routing target. */
+  .mock .app.route-target { box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--accent) 45%, transparent); border-radius: 6px; }
   .mock hr { border: none; border-top: 1px solid var(--m-hr); margin: 10px 0; }
   /* Feature stories — Apple product-page rhythm: eyebrow, big headline, copy */
   .feature {
@@ -722,8 +748,14 @@
           <div id="apps-out">
             <div class="app">&#127925; Music <span class="pct">100%</span></div>
             <div class="slider" data-app="music" data-vol-icon style="--v: 100%"><span>&#128266;</span></div>
-            <div class="app">&#127760; Safari <span class="pct">35%</span></div>
-            <div class="slider" data-app="safari" data-vol-icon style="--v: 35%"><span>&#128265;</span></div>
+            <div class="app">&#127760; Safari <span class="pct" style="display: none">35%</span></div>
+            <div class="app-routes">
+              <div class="route-dev" data-rdev="MacBook Speakers">
+                <div class="route-head">&#8627; MacBook Speakers<span class="x" title="Stop playing to this device">&#10005;</span></div>
+                <div class="slider route-slider" data-vol-icon style="--v: 60%"><span>&#128265;</span></div>
+              </div>
+            </div>
+            <div class="slider" data-app="safari" data-vol-icon style="--v: 35%; display: none"><span>&#128265;</span></div>
           </div>
           <div class="paused" id="apps-paused" hidden>Per-app volume is paused while playing to multiple outputs</div>
         </div>
@@ -778,6 +810,15 @@
     <div class="copy">
       <p>Every app that plays sound gets its own volume fader and a mute button. The levels persist across launches. Scroll the wheel or swipe the trackpad over any slider to adjust it without clicking.</p>
       <p>An app left at 100% and unmuted is touched by nothing: <strong>no tap, no processing, bit-perfect native playback</strong>. A tap exists only while a fader sits below full volume or the app is muted.</p>
+    </div>
+  </section>
+
+  <section class="feature reveal">
+    <p class="eyebrow">Per-app output</p>
+    <h2>Send an app to the outputs you choose.</h2>
+    <div class="copy">
+      <p>Drag output devices onto an app and it plays through all of them at once, each with its own volume slider, so the desk speakers and your headphones can carry one app at different levels while everything else stays on your main output. A pinned device leaves the picker, owned by that app; its ✕ hands it back.</p>
+      <p>Unplug a pinned device and the app drops it, returning to your default once the last one is gone, then re-pins it the moment it is back. Try it in the popover above — drag a device down onto an app to pin it, set each device's level, or click a ✕ to drop one.</p>
     </div>
   </section>
 
@@ -1047,10 +1088,14 @@
     // (the app excludes them the same way); disconnected Bluetooth waits in
     // the shared BLUETOOTH section and reconnects (routing there) on click.
     const syncRows = () => {
+      // Devices pinned to an app live on that app's row, gone from the picker.
+      const routed = isMulti() ? [] : [...document.querySelectorAll("#apps-out .route-dev")].map((c) => c.dataset.rdev);
       document.querySelectorAll("#mock [data-pane] .row[data-device]").forEach((row) => {
+        const out = row.closest("[data-pane]").dataset.pane === "out";
         const btOff = row.dataset.bt && !btConnected[row.dataset.bt];
-        const playing = row.closest("[data-pane]").dataset.pane === "out" && activeOut.includes(row.dataset.device);
-        row.style.display = btOff || playing ? "none" : "";
+        const playing = out && activeOut.includes(row.dataset.device);
+        const pinned = out && routed.includes(row.dataset.device);
+        row.style.display = btOff || playing || pinned ? "none" : "";
       });
       let anyDisconnected = false;
       document.querySelectorAll("#mock [data-connect]").forEach((row) => {
@@ -1082,6 +1127,75 @@
         ensureActiveIn();
       });
     });
+
+    // App rows by key, name line paired with its slider — the drop targets a
+    // dragged device lands on to route just that app.
+    const appRowByKey = {};
+    let lastAppName = null;
+    for (const child of document.getElementById("apps-out").children) {
+      if (child.classList.contains("app")) lastAppName = child;
+      else if (child.classList.contains("slider")) appRowByKey[child.dataset.app] = { name: lastAppName, slider: child };
+    }
+
+    // The head's ✕ drops just that device. When the last one goes the accent
+    // card is removed and the app's own slider returns — like the popover.
+    function wireRouteRemove(x) {
+      x.addEventListener("click", () => {
+        const dev = x.closest(".route-dev");
+        const card = dev.parentElement;
+        dev.remove();
+        if (!card.children.length) {
+          const appName = card.previousElementSibling;
+          const master = card.nextElementSibling;
+          if (master && master.classList.contains("slider")) master.style.display = "";
+          const pct = appName.querySelector(".pct");
+          if (pct) pct.style.display = "";
+          card.remove();
+        }
+        syncRows();
+      });
+    }
+    document.querySelectorAll("#mock .route-dev .x").forEach(wireRouteRemove);
+
+    // Pin an app to a device: a row with the device name and its own volume
+    // slider in the app's accent card, hiding the app's master slider.
+    const addRoute = (key, device) => {
+      const pair = appRowByKey[key];
+      if (!pair) return;
+      let card = pair.name.nextElementSibling;
+      if (!card || !card.classList.contains("app-routes")) {
+        card = document.createElement("div");
+        card.className = "app-routes";
+        pair.name.after(card);
+      }
+      if ([...card.children].some((d) => d.dataset.rdev === device)) return;
+      const dev = document.createElement("div");
+      dev.className = "route-dev";
+      dev.dataset.rdev = device;
+      const head = document.createElement("div");
+      head.className = "route-head";
+      head.append("↳ " + device);
+      const x = document.createElement("span");
+      x.className = "x";
+      x.title = "Stop playing to this device";
+      x.textContent = "✕";
+      head.append(x);
+      const slider = document.createElement("div");
+      slider.className = "slider route-slider";
+      slider.setAttribute("data-vol-icon", "");
+      slider.style.setProperty("--v", "70%");
+      const icon = document.createElement("span");
+      icon.textContent = "\u{1F50A}";
+      slider.append(icon);
+      dev.append(head, slider);
+      card.append(dev);
+      attachSlider(slider);
+      wireRouteRemove(x);
+      pair.slider.style.display = "none";
+      const pct = pair.name.querySelector(".pct");
+      if (pct) pct.style.display = "none";
+      syncRows(); // the pinned device leaves the list, now owned by the app
+    };
 
     document.querySelectorAll("#mock [data-connect]").forEach((row) => {
       row.addEventListener("click", () => {
@@ -1154,6 +1268,8 @@
         const grabOffset = startY - row.getBoundingClientRect().top;
         let dragging = false;
         let baseTop = 0;
+        let overApp = null;
+        let rowOrder = null;
         const within = (element, y) => {
           const r = element.getBoundingClientRect();
           return y >= r.top && y <= r.bottom;
@@ -1164,6 +1280,9 @@
             row.classList.add("dragging");
             mock.classList.add("drag-live");
             baseTop = row.getBoundingClientRect().top;
+            // Reaching an app to route means passing through the list; remember
+            // the order so a route drop can undo any reshuffle it caused.
+            rowOrder = [...row.parentElement.children].filter((c) => c.matches(".row[data-device]"));
           }
           if (!dragging) return;
           // confine the row to the span from the zone down to the group row
@@ -1178,13 +1297,31 @@
           if (canDemote(row)) {
             maxTop = Math.max(maxTop, rareToggle.getBoundingClientRect().top);
           }
+          // A device dropped onto an app below routes just that app there.
+          // Let the drag travel down to the apps and pick the one under the
+          // cursor; routing is off during multi-output, exactly like the app.
+          const appList = isMulti() ? [] : Object.entries(appRowByKey);
+          overApp = null;
+          if (appList.length) {
+            const appBottom = (pair) => {
+              const card = pair.name.nextElementSibling;
+              return (card?.classList.contains("app-routes") ? card : pair.slider).getBoundingClientRect().bottom;
+            };
+            maxTop = Math.max(maxTop, appList[appList.length - 1][1].name.getBoundingClientRect().top);
+            for (const [key, pair] of appList) {
+              const top = pair.name.getBoundingClientRect().top;
+              if (ev.clientY >= top && ev.clientY <= appBottom(pair)) overApp = { key, pair };
+            }
+          }
           const desiredTop = Math.min(Math.max(ev.clientY - grabOffset, minTop), maxTop);
           const center = desiredTop + row.offsetHeight / 2;
-          const overZone = within(zone, ev.clientY);
-          const overRare = within(rareToggle, ev.clientY) && canDemote(row);
+          const overZone = within(zone, ev.clientY) && !overApp;
+          const overRare = within(rareToggle, ev.clientY) && canDemote(row) && !overApp;
           zone.classList.toggle("drop-target", overZone);
           rareToggle.classList.toggle("drop-target", overRare);
-          if (!overZone && !overRare) {
+          for (const a of document.querySelectorAll("#apps-out .app.route-target")) a.classList.remove("route-target");
+          if (overApp) overApp.pair.name.classList.add("route-target");
+          if (!overZone && !overRare && !overApp) {
             for (const sib of row.parentElement.querySelectorAll(".row[data-device]")) {
               if (sib === row || sib.parentElement === rareFold) continue;
               const r = sib.getBoundingClientRect();
@@ -1211,7 +1348,11 @@
           zone.classList.remove("drop-target");
           row.dataset.dragged = "1"; // swallow the click that follows the drop
           setTimeout(() => delete row.dataset.dragged, 0); // …but only that one
-          if (ev.type === "pointerup" && within(zone, ev.clientY)) {
+          for (const a of document.querySelectorAll("#apps-out .app.route-target")) a.classList.remove("route-target");
+          if (ev.type === "pointerup" && overApp) {
+            addRoute(overApp.key, row.dataset.device); // pin this app to the device
+            rowOrder?.forEach((r) => row.parentElement.insertBefore(r, rareToggle)); // routing leaves the list order be
+          } else if (ev.type === "pointerup" && within(zone, ev.clientY)) {
             setOut([...activeOut, row.dataset.device]); // pair — play together
           } else if (ev.type === "pointerup" && within(rareToggle, ev.clientY) && canDemote(row)) {
             rareFold.append(row);


### PR DESCRIPTION
## Summary

Drag one or more output devices onto an app to pin its audio to them; the rest of the system stays on the default output. Each pinned device carries its own volume slider, so one app can play to several outputs at independent levels. A pinned device leaves the output picker — it is owned by that app.

The per-app tap aggregate fans out to every present pin (stacked, drift-compensated). The IO proc was confirmed live to fire on a multi-sub-device tap aggregate, with HAL mirroring the stream, so the gain render is unchanged. A routed tap renders transparent and each device's own VirtualMainVolume is the volume — one DeviceVolumeController apiece, the same control multi-output members use. An absent pin drops out and re-applies when the device returns.

`AppVolume` now stores a clock-first UID list; a custom decoder folds the legacy single-UID blob in so saved settings survive the upgrade. A routed app row swaps its master slider for an accent card of per-device rows.

The site popover mockup and README mirror the feature.

## Test plan

- `make build` and `make test` pass; the volume store round-trip and legacy single-UID decode are unit-tested.
- Route a playing app to two connected devices: both play, each slider moves only its own device, the speaker icon mutes just that device.
- Drop the last pin: the device returns to the picker and the app falls back to the default.
- Settings written by a prior single-route build still load.