### PR TITLE
fix: resist cache-delete eviction of the menu bar agent

### DIFF
--- a/Fader/FaderApp.swift
+++ b/Fader/FaderApp.swift
@@ -15,6 +15,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // AppKit is fully up here — safe for ImageRenderer and icon lookups.
             if RenderHarness.isActive { RenderHarness.runAndExit() }
         #endif
+        // As an LSUIElement agent with no open window, RunningBoard rates the
+        // app's termination resistance at its lowest, so under disk pressure
+        // the cache-delete daemon evicts it (exit reason 0xBADDD15C) and the
+        // icon silently vanishes — it won't relaunch until next login. Raising
+        // resistance tells the system not to reclaim us first; it's a strong
+        // hint, not a guarantee under severe pressure.
+        ProcessInfo.processInfo.disableSuddenTermination()
+        ProcessInfo.processInfo.disableAutomaticTermination("Menu bar agent stays resident")
     }
 
     func applicationWillTerminate(_ notification: Notification) {


### PR DESCRIPTION
## Problem

The menu bar app can silently disappear: as an `LSUIElement` agent with no open window, RunningBoard rates its termination resistance at the lowest level. Under disk pressure macOS's cache-delete daemon then evicts it to reclaim container caches — observed in the unified log as `exit reason namespace: 15 code: 0xBADDD15C` (`CacheDeleteAppContainerCaches requesting termination assertion`). This is a clean system kill, not a crash, so it leaves no crash report. The app is a login item but not a KeepAlive agent, so it does not relaunch — the icon stays gone until the next login.

## Fix

Disable sudden and automatic termination at launch (`ProcessInfo.disableSuddenTermination` / `disableAutomaticTermination`). This raises the process's termination resistance so the cache-delete daemon won't pick it first. It's a strong hint, not a hard guarantee under severe pressure — the underlying trigger is a near-full disk.

## Testing

`make build`, `make test` (43 tests), `pre-commit` — all green. No regression test added: termination resistance is process-global runtime state with no public getter, so there's nothing observable to assert.