### PR TITLE
fix: arm auto-switch only for devices the user dragged

### DIFF
--- a/Fader/Audio/AudioDeviceMonitor.swift
+++ b/Fader/Audio/AudioDeviceMonitor.swift
@@ -20,8 +20,8 @@ final class AudioDeviceMonitor {
     // the main list and the rarely-used group.
     @ObservationIgnored private var lastUsed: [String: Date] = [:]
     @ObservationIgnored private let usageStore: DeviceUsageStore
-    // Not observed: every priority change re-sorts `devices`, which is.
-    @ObservationIgnored private var priority: [String] = []
+    /// Not observed: every ranking change re-sorts `devices`, which is.
+    @ObservationIgnored private var ranking = DeviceRanking()
     @ObservationIgnored private let priorityStore: DevicePriorityStore
     /// Auto-switch needs a populated baseline — at startup every device
     /// "appears" at once and none of that is a hotplug event.
@@ -52,7 +52,7 @@ final class AudioDeviceMonitor {
 
     func start() {
         lastUsed = usageStore.load()
-        priority = priorityStore.load()
+        ranking = DeviceRanking(order: priorityStore.load(), armed: priorityStore.loadArmed())
         listeners = [
             AudioObjectID.system.listen(kAudioHardwarePropertyDevices) {
                 Task { @MainActor [weak self] in self?.refresh() }
@@ -83,10 +83,13 @@ final class AudioDeviceMonitor {
     }
 
     /// Persists the new order of the visible rows as the device priority and
-    /// re-sorts the list. Hidden devices keep their rank (see merge).
-    func applyOrder(_ visibleUIDs: [String]) {
-        priority = DevicePriorityStore.merge(stored: priority, visible: visibleUIDs)
-        priorityStore.save(priority)
+    /// re-sorts the list. Hidden devices keep their rank (see merge). Only the
+    /// dragged device arms for auto-switch — the rest are ranked for display.
+    func applyOrder(_ visibleUIDs: [String], moved movedUID: String) {
+        ranking.order = DevicePriorityStore.merge(stored: ranking.order, visible: visibleUIDs)
+        priorityStore.save(ranking.order)
+        ranking.armed.insert(movedUID)
+        priorityStore.saveArmed(ranking.armed)
         devices = sorted(devices)
     }
 
@@ -126,7 +129,7 @@ final class AudioDeviceMonitor {
     // MARK: - Priority
 
     private func sorted(_ list: [AudioDevice]) -> [AudioDevice] {
-        DevicePriorityPolicy.ordered(list, priority: priority)
+        DevicePriorityPolicy.ordered(list, priority: ranking.order)
     }
 
     /// Applies the policy's auto-switch decision (see DevicePriorityPolicy).
@@ -138,7 +141,7 @@ final class AudioDeviceMonitor {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: devices.map(\.uid),
             previousUIDs: previousUIDs,
-            priority: priority,
+            ranking: ranking,
             previousDefaultUID: lastDefaultUID,
             currentDefaultUID: defaultUID
         )

--- a/Fader/Audio/DevicePriorityPolicy.swift
+++ b/Fader/Audio/DevicePriorityPolicy.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// The user's device ranking: the full display order, plus the subset of
+/// devices the user has personally dragged. Ranking every visible row is a
+/// display necessity (a drop position must persist), so `order` alone cannot
+/// mean consent — `armed` does.
+struct DeviceRanking {
+    var order: [String] = []
+    var armed: Set<String> = []
+}
+
 /// Pure decisions around the user's device-priority list — display order and
 /// auto-switch gating — split from AudioDeviceMonitor so the branchy parts
 /// are unit-testable without a HAL. The monitor stays the only HAL toucher.
@@ -31,18 +40,25 @@ enum DevicePriorityPolicy {
 
     /// Gated to explicit events so auto-switch never fights a manual choice:
     /// - the previous default disappeared → override macOS's fallback with
-    ///   the best-ranked device still present;
-    /// - exactly one ranked device appeared (hotplug, not a wake storm) and
+    ///   the best-ranked armed device still present;
+    /// - exactly one armed device appeared (hotplug, not a wake storm) and
     ///   it outranks the current default → switch to it.
+    ///
+    /// Only armed devices (see DeviceRanking) are candidates.
     static func autoSwitch(presentUIDs: [String],
                            previousUIDs: Set<String>,
-                           priority: [String],
+                           ranking: DeviceRanking,
                            previousDefaultUID: String?,
                            currentDefaultUID: String?) -> AutoSwitch {
+        let priority = ranking.order
+        func eligible(_ uid: String) -> Bool {
+            ranking.armed.contains(uid) && rank(uid, priority: priority) != Int.max
+        }
+
         if let previous = previousDefaultUID, previousUIDs.contains(previous),
            !presentUIDs.contains(previous) {
             if let fallback = presentUIDs
-                .filter({ rank($0, priority: priority) != Int.max })
+                .filter(eligible)
                 .min(by: { rank($0, priority: priority) < rank($1, priority: priority) }),
                 fallback != currentDefaultUID {
                 return .fallback(toUID: fallback)
@@ -50,7 +66,7 @@ enum DevicePriorityPolicy {
             return .stay
         }
 
-        let appeared = presentUIDs.filter { !previousUIDs.contains($0) && rank($0, priority: priority) != Int.max }
+        let appeared = presentUIDs.filter { !previousUIDs.contains($0) && eligible($0) }
         guard appeared.count == 1, let candidate = appeared.first, let currentDefaultUID,
               rank(candidate, priority: priority) < rank(currentDefaultUID, priority: priority)
         else { return .stay }

--- a/Fader/Audio/DevicePriorityStore.swift
+++ b/Fader/Audio/DevicePriorityStore.swift
@@ -1,9 +1,11 @@
 import Foundation
 
 /// User-defined output device priority, an ordered list of device UIDs.
-/// Position is set by drag-reordering the device list; earlier wins. Devices
-/// never reordered are unranked and never auto-switched to. Persisted as a
-/// single JSON blob in UserDefaults.
+/// Position is set by drag-reordering the device list; earlier wins. A drag
+/// ranks every visible row (a dropped row must keep its position), so a
+/// separate armed set records which devices the user actually moved — only
+/// those are auto-switch candidates. Both persist as JSON blobs in
+/// UserDefaults.
 struct DevicePriorityStore {
     private let key: String
     private let defaults: UserDefaults
@@ -38,5 +40,13 @@ struct DevicePriorityStore {
 
     func save(_ order: [String]) {
         defaults.saveJSON(order, forKey: key)
+    }
+
+    func loadArmed() -> Set<String> {
+        Set(defaults.loadJSON([String].self, forKey: key + "Armed") ?? [])
+    }
+
+    func saveArmed(_ armed: Set<String>) {
+        defaults.saveJSON(armed.sorted(), forKey: key + "Armed")
     }
 }

--- a/Fader/UI/DeviceListSection.swift
+++ b/Fader/UI/DeviceListSection.swift
@@ -132,7 +132,7 @@ struct DeviceListSection: View {
                     fromOffsets: IndexSet(integer: index),
                     toOffset: target > index ? target + 1 : target
                 )
-                monitor.applyOrder(order)
+                monitor.applyOrder(order, moved: main[index].uid)
             }
         }
     }

--- a/Tests/BugfixTests.swift
+++ b/Tests/BugfixTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+// BUG: auto-switch targeted Bluetooth devices the user never chose.
+//
+// Reported: owner, 2026-07-10 — earbuds taken off the charger grabbed the
+//   Mac's output and mic; calls dropped to HFP (robotic voice).
+// Date: 2026-07-10
+//
+// What happened:
+//   One drag in the device list ranked EVERY visible device (a drop position
+//   only persists if all rows are ranked), so the earbuds entered the
+//   priority list unchosen at rank 1 for both directions. Their every
+//   reconnect then satisfied the hotplug rule and yanked the default output
+//   and input onto them mid-call.
+//
+// Root cause:
+//   Rank doubled as auto-switch consent; ranking is a display necessity.
+//
+// Fix:
+//   DevicePriorityPolicy.autoSwitch gained an `armed` set — UIDs the user
+//   personally dragged (AudioDeviceMonitor.applyOrder records the moved row
+//   only). Unarmed devices are never switched to; existing installs start
+//   with an empty set, disarming auto-switch until a deliberate drag.
+@Suite("bugfixes: auto-switch arming")
+struct BugAutoSwitchArmingTests {
+    @Test("bug: ranked but never-dragged device must not capture the default")
+    func bugUnarmedHotplugStays() {
+        // The earbuds sit at rank 1 because a drag of another row ranked the
+        // whole visible list — but the user never moved them.
+        let decision = DevicePriorityPolicy.autoSwitch(
+            presentUIDs: ["speakers", "earbuds"],
+            previousUIDs: ["speakers"],
+            ranking: DeviceRanking(order: ["earbuds", "speakers"], armed: ["speakers"]),
+            previousDefaultUID: "speakers",
+            currentDefaultUID: "speakers"
+        )
+
+        #expect(decision == .stay)
+    }
+
+    @Test("bug: fallback must skip ranked but never-dragged devices")
+    func bugUnarmedFallbackStays() {
+        let decision = DevicePriorityPolicy.autoSwitch(
+            presentUIDs: ["earbuds", "speakers"],
+            previousUIDs: ["mic", "earbuds", "speakers"],
+            ranking: DeviceRanking(order: ["earbuds", "mic", "speakers"], armed: []),
+            previousDefaultUID: "mic",
+            currentDefaultUID: "speakers"
+        )
+
+        #expect(decision == .stay)
+    }
+
+    @Test("armed and ranked device still hotplugs — the feature survives")
+    func armedHotplugSwitches() {
+        let decision = DevicePriorityPolicy.autoSwitch(
+            presentUIDs: ["speakers", "earbuds"],
+            previousUIDs: ["speakers"],
+            ranking: DeviceRanking(order: ["earbuds", "speakers"], armed: ["earbuds"]),
+            previousDefaultUID: "speakers",
+            currentDefaultUID: "speakers"
+        )
+
+        #expect(decision == .hotplug(toUID: "earbuds"))
+    }
+
+    @Test("armed set round-trips and starts empty for existing installs")
+    func armedRoundTrip() throws {
+        let suite = "BugAutoSwitchArmingTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let store = DevicePriorityStore(defaults: defaults)
+
+        #expect(store.loadArmed().isEmpty)
+        store.saveArmed(["earbuds"])
+        #expect(store.loadArmed() == ["earbuds"])
+    }
+}

--- a/Tests/DevicePriorityPolicyTests.swift
+++ b/Tests/DevicePriorityPolicyTests.swift
@@ -36,7 +36,7 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["speakers", "headphones"],
             previousUIDs: ["speakers"],
-            priority: ["headphones", "speakers"],
+            ranking: DeviceRanking(order: ["headphones", "speakers"], armed: ["headphones", "speakers"]),
             previousDefaultUID: "speakers",
             currentDefaultUID: "speakers"
         )
@@ -49,7 +49,7 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["speakers", "headphones"],
             previousUIDs: ["speakers"],
-            priority: ["speakers", "headphones"],
+            ranking: DeviceRanking(order: ["speakers", "headphones"], armed: ["speakers", "headphones"]),
             previousDefaultUID: "speakers",
             currentDefaultUID: "speakers"
         )
@@ -62,7 +62,10 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["speakers", "headphones", "dock"],
             previousUIDs: ["speakers"],
-            priority: ["headphones", "dock", "speakers"],
+            ranking: DeviceRanking(
+                order: ["headphones", "dock", "speakers"],
+                armed: ["headphones", "dock", "speakers"]
+            ),
             previousDefaultUID: "speakers",
             currentDefaultUID: "speakers"
         )
@@ -75,7 +78,7 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["speakers", "stranger"],
             previousUIDs: ["speakers"],
-            priority: ["speakers"],
+            ranking: DeviceRanking(order: ["speakers"], armed: ["speakers"]),
             previousDefaultUID: "speakers",
             currentDefaultUID: "speakers"
         )
@@ -88,7 +91,7 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["speakers", "headphones"],
             previousUIDs: ["speakers"],
-            priority: ["headphones"],
+            ranking: DeviceRanking(order: ["headphones"], armed: ["headphones"]),
             previousDefaultUID: nil,
             currentDefaultUID: nil
         )
@@ -101,7 +104,10 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["dock", "speakers"],
             previousUIDs: ["headphones", "dock", "speakers"],
-            priority: ["headphones", "dock", "speakers"],
+            ranking: DeviceRanking(
+                order: ["headphones", "dock", "speakers"],
+                armed: ["headphones", "dock", "speakers"]
+            ),
             previousDefaultUID: "headphones",
             currentDefaultUID: "speakers"
         )
@@ -114,7 +120,10 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["dock", "speakers"],
             previousUIDs: ["headphones", "dock", "speakers"],
-            priority: ["headphones", "dock", "speakers"],
+            ranking: DeviceRanking(
+                order: ["headphones", "dock", "speakers"],
+                armed: ["headphones", "dock", "speakers"]
+            ),
             previousDefaultUID: "headphones",
             currentDefaultUID: "dock"
         )
@@ -127,7 +136,7 @@ struct AutoSwitchPolicyTests {
         let decision = DevicePriorityPolicy.autoSwitch(
             presentUIDs: ["stranger"],
             previousUIDs: ["headphones", "stranger"],
-            priority: ["headphones"],
+            ranking: DeviceRanking(order: ["headphones"], armed: ["headphones"]),
             previousDefaultUID: "headphones",
             currentDefaultUID: "stranger"
         )


### PR DESCRIPTION
## Summary

Fixes #26. A drag in the device list ranks every visible row (the drop position must persist), and rank alone counted as consent for auto-switch, so devices the user never touched became switch targets. This PR records the dragged UIDs in an armed set (`DeviceRanking.armed`, persisted per direction next to the order) and lets only armed devices win a hotplug or fallback switch. Existing installs start unarmed: auto-switch goes dormant until a deliberate drag re-arms a device.

## Test plan

- [x] `make test`: bug tests reproduce the report (a ranked but never-dragged device must not capture the default; fallback skips unarmed devices), plus an armed-set round-trip; existing policy tests updated to the new signature.
- [ ] Manual: drag one row, confirm only that device auto-switches on reconnect.
