### PR TITLE
fix: rebuild wedged taps and adapt render to the output channel layout

### DIFF
--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -277,9 +277,9 @@ final class MixerEngine {
         // Saved volumes survive and re-apply once multi-output dissolves.
         guard !multiOutput.isActive else { return }
 
-        let outputUIDs: [String]
+        let outputs: [ProcessTap.Output]
         do {
-            outputUIDs = try resolvedOutputUIDs(for: entry)
+            outputs = try resolvedOutputs(for: entry)
         } catch {
             // Transient device churn (output switching), not a permission issue.
             Self.logger.error("Default device read failed: \(error.localizedDescription)")
@@ -296,7 +296,7 @@ final class MixerEngine {
                 volume: routed ? 1.0 : entry.volume,
                 isMuted: routed ? false : entry.isMuted
             )
-            try tap.activate(outputDeviceUIDs: outputUIDs)
+            try tap.activate(outputs: outputs)
             taps[app.bundleID] = tap
             needsAudioCapturePermission = false
         } catch {
@@ -306,31 +306,31 @@ final class MixerEngine {
         }
     }
 
-    /// The UID an app's tap should play through: its pinned route when that
-    /// device is present, otherwise the system default. A pinned-but-absent
-    /// device falls back to the default so the app stays audible until it
-    /// returns — the stored route survives for when it does.
-    private func resolvedOutputUIDs(for entry: AppVolume) throws -> [String] {
-        let present = entry.outputDeviceUIDs.compactMap { uid in
-            deviceMonitor.devices.first { $0.uid == uid }
-        }
+    /// The devices an app's tap should play through: its pinned route when
+    /// present, otherwise the system default. A pinned-but-absent device falls
+    /// back to the default so the app stays audible until it returns — the
+    /// stored route survives for when it does.
+    private func resolvedOutputs(for entry: AppVolume) throws -> [ProcessTap.Output] {
+        let present = entry.outputDeviceUIDs.compactMap { uid in deviceMonitor.devices.first { $0.uid == uid } }
         // Clock leads: a Bluetooth clock drifts, so a wired/built-in member is
         // preferred to drive the aggregate, mirroring multi-output.
         guard let clock = MultiOutputPolicy.clock(among: present) else {
-            return try [AudioObjectID.readDefaultOutputDevice().readDeviceUID()]
+            let id = try AudioObjectID.readDefaultOutputDevice()
+            return try [ProcessTap.Output(uid: id.readDeviceUID(), id: id)]
         }
-        return [clock.uid] + present.map(\.uid).filter { $0 != clock.uid }
+        return ([clock] + present.filter { $0.uid != clock.uid })
+            .map { ProcessTap.Output(uid: $0.uid, id: $0.id) }
     }
 
-    /// Rebuilds only the taps whose target device no longer matches where they
-    /// play: a default switch moves the follow-default taps, a routed device
-    /// appearing or vanishing moves the pinned ones, and unrelated apps are left
-    /// untouched so they don't blip. One rule covers all three.
+    /// Rebuilds only the taps that no longer play where they should, so
+    /// unrelated apps don't blip. Stale = resolved targets changed (object IDs
+    /// too — devices re-publish under an old UID), aggregate died, or resolve
+    /// failed; a wedged tap keeps its app muted, dropping it un-mutes.
     private func reconcileTapRouting() {
         for (bundleID, tap) in taps {
-            guard let entry = volumes[bundleID],
-                  let desired = try? resolvedOutputUIDs(for: entry),
-                  desired != tap.activatedOutputUIDs else { continue }
+            guard let entry = volumes[bundleID] else { continue }
+            if let desired = try? resolvedOutputs(for: entry),
+               desired == tap.activatedOutputs, tap.isAlive { continue }
             tap.invalidate()
             taps[bundleID] = nil
         }

--- a/Fader/Audio/ProcessTap.swift
+++ b/Fader/Audio/ProcessTap.swift
@@ -38,11 +38,20 @@ final class ProcessTap: @unchecked Sendable {
 
     let processObjectIDs: [AudioObjectID]
 
-    /// UIDs of the output devices this tap's aggregate fans out to, clock
-    /// first. The aggregate pins them at activation, so a route or default
-    /// change is honoured by rebuilding the tap, not mutating it — this records
-    /// the current pins.
-    private(set) var activatedOutputUIDs: [String] = []
+    /// A resolved output device: the UID names the aggregate's sub-device, the
+    /// object ID catches a device that died and re-published under the same
+    /// UID — the aggregate stays bound to the corpse and the tapped app would
+    /// otherwise sit muted with nobody re-rendering it.
+    struct Output: Equatable {
+        let uid: String
+        let id: AudioObjectID
+    }
+
+    /// The output devices this tap's aggregate fans out to, clock first. The
+    /// aggregate pins them at activation, so a route or default change is
+    /// honoured by rebuilding the tap, not mutating it — this records the
+    /// current pins.
+    private(set) var activatedOutputs: [Output] = []
 
     var volume: Float {
         get { _volume }
@@ -65,10 +74,10 @@ final class ProcessTap: @unchecked Sendable {
     /// (and main) sub-device; any others stack on with drift compensation, so
     /// the app fans out to several devices at once.
     @MainActor
-    func activate(outputDeviceUIDs: [String]) throws {
+    func activate(outputs: [Output]) throws {
         guard !aggregateID.isValid else { return }
-        guard let clockUID = outputDeviceUIDs.first else { return }
-        activatedOutputUIDs = outputDeviceUIDs
+        guard let clockUID = outputs.first?.uid else { return }
+        activatedOutputs = outputs
 
         let description = CATapDescription(stereoMixdownOfProcesses: processObjectIDs)
         description.uuid = UUID()
@@ -88,15 +97,15 @@ final class ProcessTap: @unchecked Sendable {
             kAudioAggregateDeviceClockDeviceKey: clockUID,
             kAudioAggregateDeviceIsPrivateKey: true,
             kAudioAggregateDeviceTapAutoStartKey: true,
-            kAudioAggregateDeviceSubDeviceListKey: outputDeviceUIDs.map {
-                [kAudioSubDeviceUIDKey: $0, kAudioSubDeviceDriftCompensationKey: $0 != clockUID]
+            kAudioAggregateDeviceSubDeviceListKey: outputs.map {
+                [kAudioSubDeviceUIDKey: $0.uid, kAudioSubDeviceDriftCompensationKey: $0.uid != clockUID]
             },
             kAudioAggregateDeviceTapListKey: [[
                 kAudioSubTapUIDKey: description.uuid.uuidString,
                 kAudioSubTapDriftCompensationKey: true,
             ]],
         ]
-        if outputDeviceUIDs.count > 1 {
+        if outputs.count > 1 {
             aggregateDescription[kAudioAggregateDeviceIsStackedKey] = true
         }
 
@@ -148,6 +157,17 @@ final class ProcessTap: @unchecked Sendable {
         }
     }
 
+    /// Whether the private aggregate still exists HAL-side. Device churn can
+    /// kill it under the tap; `.mutedWhenTapped` then leaves the app muted
+    /// with nobody re-rendering it, so a dead aggregate means rebuild now.
+    @MainActor
+    var isAlive: Bool {
+        guard aggregateID.isValid else { return false }
+        var alive: UInt32 = 0
+        guard (try? aggregateID.read(kAudioDevicePropertyDeviceIsAlive, into: &alive)) != nil else { return false }
+        return alive != 0
+    }
+
     /// Tears down in the HAL-required order: stop → IO proc → aggregate → tap.
     /// Releasing the tap restores the app's native output.
     @MainActor
@@ -197,35 +217,21 @@ final class ProcessTap: @unchecked Sendable {
 
         for (index, outBuffer) in outputs.enumerated() {
             guard let outData = outBuffer.mData else { continue }
-            let outSamples = outData.assumingMemoryBound(to: Float.self)
-            let outCount = Int(outBuffer.mDataByteSize) / MemoryLayout<Float>.size
-
             guard index < inputs.count, let inData = inputs[index].mData else {
                 memset(outData, 0, Int(outBuffer.mDataByteSize))
                 continue
             }
-            let inSamples = inData.assumingMemoryBound(to: Float.self)
-            let count = min(Int(inputs[index].mDataByteSize) / MemoryLayout<Float>.size, outCount)
-            let channels = max(1, Int(outBuffer.mNumberChannels))
-
             // One ramp shared across the buffer list; in practice taps deliver
             // a single interleaved buffer, so this is exact.
-            var frameGain = gain
-            for frame in stride(from: 0, to: count, by: channels) {
-                frameGain += (targetGain - frameGain) * ramp
-                for channel in 0 ..< channels where frame + channel < count {
-                    outSamples[frame + channel] = inSamples[frame + channel] * frameGain
-                }
-            }
-            // Snap once converged: stops the asymptotic tail (denormal-prone
-            // when ramping to 0 on non-Apple-silicon FPUs).
-            if abs(frameGain - targetGain) < 1e-6 {
-                frameGain = targetGain
-            }
-            gain = frameGain
-            if count < outCount {
-                memset(outSamples.advanced(by: count), 0, (outCount - count) * MemoryLayout<Float>.size)
-            }
+            gain = TapMix.mix(
+                input: inData.assumingMemoryBound(to: Float.self),
+                inputLayout: TapMix.Layout(channels: Int(inputs[index].mNumberChannels),
+                                           count: Int(inputs[index].mDataByteSize) / MemoryLayout<Float>.size),
+                output: outData.assumingMemoryBound(to: Float.self),
+                outputLayout: TapMix.Layout(channels: Int(outBuffer.mNumberChannels),
+                                            count: Int(outBuffer.mDataByteSize) / MemoryLayout<Float>.size),
+                gain: TapMix.Gain(current: gain, target: targetGain, ramp: ramp)
+            )
         }
         _currentGain = gain
     }

--- a/Fader/Audio/TapMix.swift
+++ b/Fader/Audio/TapMix.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// The pure math of ProcessTap's render: ramped gain plus channel-layout
+/// adaptation, split from the tap so it is unit-testable without a HAL.
+/// Called from the real-time IO callback — no allocation, no locks.
+enum TapMix {
+    /// One interleaved buffer's shape: channel count and total sample count.
+    struct Layout {
+        let channels: Int
+        let count: Int
+    }
+
+    /// The gain ramp state: where it is, where it heads, how fast per frame.
+    struct Gain {
+        let current: Float
+        let target: Float
+        let ramp: Float
+    }
+
+    /// Applies the ramped gain while adapting the tap's channel layout to the
+    /// output stream's. The tap always delivers a stereo mixdown, but the
+    /// output can be mono (a Bluetooth headset dropping to HFP mid-call) or
+    /// wider; index-matched copying would smear interleaved frames across
+    /// time. Equal layouts copy 1:1, a narrower output averages each frame's
+    /// channels, a wider one repeats the last input channel. Returns the gain
+    /// after the final frame.
+    static func mix(input: UnsafePointer<Float>, inputLayout: Layout,
+                    output: UnsafeMutablePointer<Float>, outputLayout: Layout,
+                    gain: Gain) -> Float {
+        let inChannels = max(1, inputLayout.channels)
+        let outChannels = max(1, outputLayout.channels)
+        let frames = min(inputLayout.count / inChannels, outputLayout.count / outChannels)
+        let targetGain = gain.target
+        let ramp = gain.ramp
+        var frameGain = gain.current
+
+        for frame in 0 ..< frames {
+            frameGain += (targetGain - frameGain) * ramp
+            let inBase = frame * inChannels
+            let outBase = frame * outChannels
+            if inChannels == outChannels {
+                for channel in 0 ..< outChannels {
+                    output[outBase + channel] = input[inBase + channel] * frameGain
+                }
+            } else if outChannels == 1 {
+                var sum: Float = 0
+                for channel in 0 ..< inChannels {
+                    sum += input[inBase + channel]
+                }
+                output[outBase] = sum / Float(inChannels) * frameGain
+            } else {
+                for channel in 0 ..< outChannels {
+                    output[outBase + channel] = input[inBase + min(channel, inChannels - 1)] * frameGain
+                }
+            }
+        }
+        // Snap once converged: stops the asymptotic tail (denormal-prone
+        // when ramping to 0 on non-Apple-silicon FPUs).
+        if abs(frameGain - targetGain) < 1e-6 {
+            frameGain = targetGain
+        }
+        let written = frames * outChannels
+        if written < outputLayout.count {
+            output.advanced(by: written).update(repeating: 0, count: outputLayout.count - written)
+        }
+        return frameGain
+    }
+}

--- a/Tests/TapMixTests.swift
+++ b/Tests/TapMixTests.swift
@@ -1,0 +1,93 @@
+import Testing
+
+/// Runs TapMix.mix over value arrays; converged gain (gain == target) unless
+/// a test exercises the ramp itself.
+private func mixed(input: [Float], inputChannels: Int,
+                   outputChannels: Int, outputCount: Int,
+                   gain: Float = 1, targetGain: Float = 1, ramp: Float = 1) -> (output: [Float], gain: Float) {
+    var output = [Float](repeating: .nan, count: outputCount)
+    var finalGain: Float = 0
+    input.withUnsafeBufferPointer { inPtr in
+        output.withUnsafeMutableBufferPointer { outPtr in
+            finalGain = TapMix.mix(
+                input: inPtr.baseAddress!,
+                inputLayout: TapMix.Layout(channels: inputChannels, count: input.count),
+                output: outPtr.baseAddress!,
+                outputLayout: TapMix.Layout(channels: outputChannels, count: outputCount),
+                gain: TapMix.Gain(current: gain, target: targetGain, ramp: ramp)
+            )
+        }
+    }
+    return (output, finalGain)
+}
+
+// BUG: tapped apps sounded garbled ("robotic voice") on mono outputs.
+//
+// Reported: owner, 2026-07-10 — voice in Telegram calls turned robotic while
+//   the app had a Fader volume set and a Bluetooth headset was in call mode.
+// Date: 2026-07-10
+//
+// What happened:
+//   A Bluetooth headset drops to the mono HFP profile during calls. The tap
+//   always delivers an interleaved stereo mixdown, and the render copied it
+//   sample-for-sample into the mono output stream — L,R pairs became
+//   consecutive mono frames, playing the audio garbled at half speed.
+//
+// Root cause:
+//   The render indexed input and output buffers identically, assuming their
+//   channel layouts matched; nothing re-checked the layout after activation.
+//
+// Fix:
+//   TapMix.mix (extracted from ProcessTap.render) adapts layouts per frame:
+//   narrower outputs average each frame's channels, wider ones repeat the
+//   last channel.
+@Suite("bugfixes: TapMix channel adaptation")
+struct BugTapMixChannelTests {
+    @Test("bug: stereo tap into a mono (HFP) output downmixes per frame")
+    func bugStereoToMonoDownmix() {
+        let stereo: [Float] = [0.25, 0.75, -1.0, 1.0, 0.5, 0.5]
+
+        let result = mixed(input: stereo, inputChannels: 2, outputChannels: 1, outputCount: 3)
+
+        #expect(result.output == [0.5, 0.0, 0.5])
+    }
+
+    @Test("matching layouts copy 1:1 with gain applied")
+    func matchingLayouts() {
+        let stereo: [Float] = [0.25, 0.5, -1.0, 1.0]
+
+        let result = mixed(input: stereo, inputChannels: 2, outputChannels: 2, outputCount: 4,
+                           gain: 0.5, targetGain: 0.5)
+
+        #expect(result.output == [0.125, 0.25, -0.5, 0.5])
+        #expect(result.gain == 0.5)
+    }
+
+    @Test("mono tap into a stereo output repeats the channel")
+    func monoToStereo() {
+        let result = mixed(input: [0.25, -0.5], inputChannels: 1, outputChannels: 2, outputCount: 4)
+
+        #expect(result.output == [0.25, 0.25, -0.5, -0.5])
+    }
+
+    @Test("output frames the input can't fill are zeroed, not left stale")
+    func zeroFillsTail() {
+        let result = mixed(input: [0.5, 0.5], inputChannels: 2, outputChannels: 2, outputCount: 6)
+
+        #expect(result.output == [0.5, 0.5, 0, 0, 0, 0])
+    }
+
+    @Test("gain ramps monotonically toward the target across frames")
+    func rampProgresses() {
+        let input = [Float](repeating: 1, count: 8)
+
+        let result = mixed(input: input, inputChannels: 1, outputChannels: 1, outputCount: 8,
+                           gain: 0, targetGain: 1, ramp: 0.5)
+
+        for pair in zip(result.output, result.output.dropFirst()) {
+            #expect(pair.0 < pair.1)
+        }
+        #expect(result.output[0] == 0.5)
+        #expect(result.gain > 0.99)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -104,6 +104,7 @@ targets:
       - Fader/Audio/DevicePriorityPolicy.swift
       - Fader/Audio/MultiOutputPolicy.swift
       - Fader/Audio/VolumeTaper.swift
+      - Fader/Audio/TapMix.swift
       # Property wrappers and AudioDirection; nothing in the tests touches
       # a live HAL.
       - Fader/Audio/HALProperty.swift


### PR DESCRIPTION
## Summary

Fixes #27. Two changes in the tap chain. Staleness: taps now record the resolved device object IDs next to the UIDs, and `reconcileTapRouting` also checks the aggregate is still alive, dropping the tap when anything mismatches or the resolve fails — the app un-mutes at full volume instead of sitting silent, and the next sync re-taps it. Render: the mix (extracted to `TapMix` so the hostless tests can cover it) adapts the tap's stereo mixdown to the output's channel count per frame; mono outputs get the frame average, wider outputs repeat the last channel.

## Test plan

- [x] `make test`: bug test reproduces the mono garble (stereo input into a mono output downmixes per frame instead of smearing across time), plus layout-matrix and ramp tests.
- [ ] Manual: set an app volume, force device churn (toggle Bluetooth) mid-playback, confirm the app never stays silent; call on a Bluetooth headset with a tapped app, confirm clean audio in HFP.

The staleness path itself is HAL-bound and has no hostless test; it was verified by tracing the reconcile flow.
