### PR TITLE
fix: resync audio state after wake

### DIFF
--- a/Fader/Audio/AudioDeviceMonitor.swift
+++ b/Fader/Audio/AudioDeviceMonitor.swift
@@ -27,6 +27,10 @@ final class AudioDeviceMonitor {
     /// "appears" at once and none of that is a hotplug event.
     @ObservationIgnored private var hasBaseline = false
     @ObservationIgnored private var lastDefaultUID: String?
+    /// HAL emits device/default changes in bursts (one per aggregate member and
+    /// property). Collapse one main-queue burst into one enumeration instead of
+    /// queueing a full synchronous refresh for every callback.
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
 
     init(direction: AudioDirection = .output) {
         self.direction = direction
@@ -55,10 +59,10 @@ final class AudioDeviceMonitor {
         ranking = DeviceRanking(order: priorityStore.load(), armed: priorityStore.loadArmed())
         listeners = [
             AudioObjectID.system.listen(kAudioHardwarePropertyDevices) {
-                Task { @MainActor [weak self] in self?.refresh() }
+                Task { @MainActor [weak self] in self?.scheduleRefresh() }
             },
             AudioObjectID.system.listen(direction.defaultDeviceSelector) {
-                Task { @MainActor [weak self] in self?.refresh() }
+                Task { @MainActor [weak self] in self?.scheduleRefresh() }
             },
         ]
         refresh()
@@ -102,6 +106,11 @@ final class AudioDeviceMonitor {
     }
 
     func refresh() {
+        // An explicit refresh (startup/wake/final Bluetooth fallback) supersedes
+        // a queued burst refresh that has not started yet.
+        refreshTask?.cancel()
+        refreshTask = nil
+
         defaultDeviceID = (try? AudioObjectID.readDefaultDevice(direction)) ?? .unknown
         let defaultUID = try? defaultDeviceID.readDeviceUID()
         stampDefaultDevice(uid: defaultUID)
@@ -124,6 +133,24 @@ final class AudioDeviceMonitor {
         autoSwitch(previousUIDs: previousUIDs, defaultUID: defaultUID)
         lastDefaultUID = defaultUID
         hasBaseline = true
+    }
+
+    deinit {
+        refreshTask?.cancel()
+    }
+
+    private func scheduleRefresh() {
+        guard refreshTask == nil else { return }
+        refreshTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(50), tolerance: .milliseconds(25))
+            } catch {
+                return
+            }
+            guard let self else { return }
+            refreshTask = nil
+            refresh()
+        }
     }
 
     // MARK: - Priority

--- a/Fader/Audio/AudioPowerMonitor.swift
+++ b/Fader/Audio/AudioPowerMonitor.swift
@@ -1,0 +1,32 @@
+import AppKit
+
+/// Bridges workspace power notifications onto the main actor. The monitor is
+/// intentionally app-lifetime: NotificationCenter retains opaque observer
+/// tokens, while their callbacks only retain this object weakly.
+@MainActor
+final class AudioPowerMonitor {
+    private let onSleep: @MainActor @Sendable () -> Void
+    private let onWake: @MainActor @Sendable () -> Void
+    private var observers: [NSObjectProtocol] = []
+
+    init(onSleep: @escaping @MainActor @Sendable () -> Void,
+         onWake: @escaping @MainActor @Sendable () -> Void) {
+        self.onSleep = onSleep
+        self.onWake = onWake
+    }
+
+    func start() {
+        guard observers.isEmpty else { return }
+        let center = NSWorkspace.shared.notificationCenter
+        observers = [
+            center.addObserver(forName: NSWorkspace.willSleepNotification,
+                               object: NSWorkspace.shared, queue: .main) { [weak self] _ in
+                Task { @MainActor in self?.onSleep() }
+            },
+            center.addObserver(forName: NSWorkspace.didWakeNotification,
+                               object: NSWorkspace.shared, queue: .main) { [weak self] _ in
+                Task { @MainActor in self?.onWake() }
+            },
+        ]
+    }
+}

--- a/Fader/Audio/AudioProcessMonitor.swift
+++ b/Fader/Audio/AudioProcessMonitor.swift
@@ -37,8 +37,13 @@ final class AudioProcessMonitor {
             while !Task.isCancelled {
                 // Generous tolerance lets the kernel coalesce the wakeup with
                 // other timers — playing-state freshness doesn't need precision.
-                try? await Task.sleep(for: .seconds(2), tolerance: .milliseconds(500))
-                self?.refresh()
+                do {
+                    try await Task.sleep(for: .seconds(2), tolerance: .milliseconds(500))
+                } catch {
+                    break
+                }
+                guard let self else { break }
+                refresh()
             }
         }
         refresh()

--- a/Fader/Audio/MixerEngine+Bluetooth.swift
+++ b/Fader/Audio/MixerEngine+Bluetooth.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+extension MixerEngine {
+    /// Paired IOBluetooth peer of a HAL device, when one matches by MAC.
+    func bluetoothPeer(for device: AudioDevice) -> BluetoothAudioDevice? {
+        bluetooth.paired.first { device.matches(bluetoothID: $0.id) }
+    }
+
+    /// Connects Bluetooth headphones and routes output to them once CoreAudio
+    /// picks the device up.
+    func connectBluetooth(_ device: BluetoothAudioDevice) {
+        bluetooth.connect(device) { [weak self] connected in
+            self?.routeWhenAvailable(connected)
+        }
+    }
+
+    /// The HAL device for a Bluetooth peer appears a moment after the link
+    /// opens; its UID starts with the MAC address. Poll briefly, then route.
+    /// A new connect cancels the previous poll so rapid reconnects don't race.
+    private func routeWhenAvailable(_ device: BluetoothAudioDevice) {
+        routingTask?.cancel()
+        routingTask = Task { @MainActor [weak self] in
+            for _ in 0 ..< 16 {
+                guard let self, !Task.isCancelled else { return }
+                if let halDevice = deviceMonitor.devices.first(where: { $0.matches(bluetoothID: device.id) }) {
+                    deviceMonitor.setDefault(halDevice)
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(300))
+            }
+            // HAL notifications normally populated the monitor. One explicit
+            // read at the deadline covers a lost callback without hammering the
+            // main actor with sixteen full device enumerations.
+            guard let self, !Task.isCancelled else { return }
+            deviceMonitor.refresh()
+            if let halDevice = deviceMonitor.devices.first(where: { $0.matches(bluetoothID: device.id) }) {
+                deviceMonitor.setDefault(halDevice)
+            }
+        }
+    }
+
+    /// Twice: once now, once after IOBluetooth's connection state has had a
+    /// moment to settle — it lags the HAL by a beat in both directions.
+    func refreshBluetoothSoon() {
+        bluetooth.refresh()
+        bluetoothRefreshTask?.cancel()
+        bluetoothRefreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            self?.bluetooth.refresh()
+        }
+    }
+}

--- a/Fader/Audio/MixerEngine+Power.swift
+++ b/Fader/Audio/MixerEngine+Power.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension MixerEngine {
+    /// Transient connect/routing work is meaningless across sleep and can wake
+    /// into stale object IDs. Stable taps stay alive until the wake resync can
+    /// inspect them — eagerly dropping them would let apps resume at full volume.
+    func prepareForSleep() {
+        routingTask?.cancel()
+        routingTask = nil
+        bluetoothRefreshTask?.cancel()
+        bluetoothRefreshTask = nil
+        wakeResyncTask?.cancel()
+        wakeResyncTask = nil
+    }
+
+    func recoverAfterWake() {
+        wakeResyncTask?.cancel()
+        resyncAudioState()
+        // Drivers and IOBluetooth often publish their final object IDs shortly
+        // after didWake. One controlled second pass replaces a notification
+        // storm and catches devices that were not ready on the immediate pass.
+        wakeResyncTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(1), tolerance: .milliseconds(250))
+            } catch {
+                return
+            }
+            guard let self else { return }
+            wakeResyncTask = nil
+            resyncAudioState()
+        }
+    }
+
+    private func resyncAudioState() {
+        deviceMonitor.refresh()
+        inputDeviceMonitor.refresh()
+        multiOutput.handleDevicesChanged(present: deviceMonitor.devices)
+        systemVolume.resync()
+        inputVolume.resync()
+        processMonitor.refresh()
+        bluetooth.refresh()
+        reconcileTapRouting()
+    }
+}

--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -35,8 +35,10 @@ final class MixerEngine {
     @ObservationIgnored private let store = VolumeStore()
     @ObservationIgnored private var deviceListener: HALListener?
     @ObservationIgnored private var saveTask: Task<Void, Never>?
-    @ObservationIgnored private var routingTask: Task<Void, Never>?
-    @ObservationIgnored private var bluetoothRefreshTask: Task<Void, Never>?
+    @ObservationIgnored var routingTask: Task<Void, Never>?
+    @ObservationIgnored var bluetoothRefreshTask: Task<Void, Never>?
+    @ObservationIgnored var wakeResyncTask: Task<Void, Never>?
+    @ObservationIgnored private var powerMonitor: AudioPowerMonitor?
 
     #if RENDER_SHOTS
         /// Render harness only: mark the engine started and publish per-app
@@ -68,6 +70,11 @@ final class MixerEngine {
 
         observeApps()
         observeDevices()
+        powerMonitor = AudioPowerMonitor(
+            onSleep: { [weak self] in self?.prepareForSleep() },
+            onWake: { [weak self] in self?.recoverAfterWake() }
+        )
+        powerMonitor?.start()
         syncTaps()
         isStarted = true
     }
@@ -86,37 +93,6 @@ final class MixerEngine {
         var entry = volumes[app.bundleID] ?? AppVolume()
         entry.isMuted.toggle()
         apply(entry, to: app)
-    }
-
-    /// Paired IOBluetooth peer of a HAL device, when one matches by MAC.
-    func bluetoothPeer(for device: AudioDevice) -> BluetoothAudioDevice? {
-        bluetooth.paired.first { device.matches(bluetoothID: $0.id) }
-    }
-
-    /// Connects Bluetooth headphones and routes output to them once CoreAudio
-    /// picks the device up.
-    func connectBluetooth(_ device: BluetoothAudioDevice) {
-        bluetooth.connect(device) { [weak self] connected in
-            self?.routeWhenAvailable(connected)
-        }
-    }
-
-    /// The HAL device for a Bluetooth peer appears a moment after the link
-    /// opens; its UID starts with the MAC address. Poll briefly, then route.
-    /// A new connect cancels the previous poll so rapid reconnects don't race.
-    private func routeWhenAvailable(_ device: BluetoothAudioDevice) {
-        routingTask?.cancel()
-        routingTask = Task { @MainActor [weak self] in
-            for _ in 0 ..< 16 {
-                guard let self, !Task.isCancelled else { return }
-                deviceMonitor.refresh()
-                if let halDevice = deviceMonitor.devices.first(where: { $0.matches(bluetoothID: device.id) }) {
-                    deviceMonitor.setDefault(halDevice)
-                    return
-                }
-                try? await Task.sleep(for: .milliseconds(300))
-            }
-        }
     }
 
     /// Adds a device to the active outputs, building the multi-output route
@@ -192,18 +168,6 @@ final class MixerEngine {
                 self.reconcileTapRouting()
                 self.observeDevices()
             }
-        }
-    }
-
-    /// Twice: once now, once after IOBluetooth's connection state has had a
-    /// moment to settle — it lags the HAL by a beat in both directions.
-    private func refreshBluetoothSoon() {
-        bluetooth.refresh()
-        bluetoothRefreshTask?.cancel()
-        bluetoothRefreshTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(2))
-            guard !Task.isCancelled else { return }
-            self?.bluetooth.refresh()
         }
     }
 
@@ -326,7 +290,7 @@ final class MixerEngine {
     /// unrelated apps don't blip. Stale = resolved targets changed (object IDs
     /// too — devices re-publish under an old UID), aggregate died, or resolve
     /// failed; a wedged tap keeps its app muted, dropping it un-mutes.
-    private func reconcileTapRouting() {
+    func reconcileTapRouting() {
         for (bundleID, tap) in taps {
             guard let entry = volumes[bundleID] else { continue }
             if let desired = try? resolvedOutputs(for: entry),

--- a/Fader/Audio/SystemVolumeController.swift
+++ b/Fader/Audio/SystemVolumeController.swift
@@ -65,6 +65,12 @@ final class SystemVolumeController {
         }
     }
 
+    /// Rebinds listeners after sleep/wake even if HAL omitted the expected
+    /// default-device notification.
+    func resync() {
+        attachToDefaultDevice()
+    }
+
     // MARK: - Private
 
     private func attachToDefaultDevice() {


### PR DESCRIPTION
## Summary
- coalesce HAL device-change bursts before enumerating devices
- resync device, volume, process, Bluetooth, and tap state after wake
- stop polling HAL repeatedly while waiting for a Bluetooth route
- make polling cancellation finish without an extra refresh

## Verification
- make test: 52 tests passed
- SwiftLint: 0 violations