### PR TITLE
fix: harden rare app lifecycle paths

### DIFF
--- a/Fader/Audio/AudioApp.swift
+++ b/Fader/Audio/AudioApp.swift
@@ -27,3 +27,34 @@ struct AudioApp: Identifiable, Hashable {
             ?? NSWorkspace.shared.icon(for: .applicationBundle)
     }
 }
+
+extension AudioApp {
+    /// Multiple independently launched copies of one application can own
+    /// different HAL process objects while sharing a bundle identifier. Fader
+    /// exposes one slider per bundle, so fold those copies together instead of
+    /// letting a duplicate dictionary key trap the main actor.
+    static func coalescedByBundleID(_ apps: [AudioApp]) -> [AudioApp] {
+        var indices: [String: Int] = [:]
+        var result: [AudioApp] = []
+
+        for app in apps {
+            guard let index = indices[app.bundleID] else {
+                indices[app.bundleID] = result.count
+                result.append(app)
+                continue
+            }
+
+            let existing = result[index]
+            let representative = existing.id <= app.id ? existing : app
+            result[index] = AudioApp(
+                id: representative.id,
+                bundleID: app.bundleID,
+                name: representative.name,
+                objectIDs: Array(Set(existing.objectIDs + app.objectIDs)).sorted(),
+                isPlaying: existing.isPlaying || app.isPlaying,
+                isRecording: existing.isRecording || app.isRecording
+            )
+        }
+        return result
+    }
+}

--- a/Fader/Audio/AudioProcessMonitor.swift
+++ b/Fader/Audio/AudioProcessMonitor.swift
@@ -129,6 +129,7 @@ final class AudioProcessMonitor {
                 isRecording: group.recording
             )
         }
+        nextApps = AudioApp.coalescedByBundleID(nextApps)
 
         // Playing apps first, then alphabetical; stable for equal keys.
         nextApps.sort {

--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -212,7 +212,8 @@ final class MixerEngine {
     /// Ensures every non-neutral running app has a live tap covering its
     /// current process set, and every gone app's tap is released.
     func syncTaps() {
-        let running = Dictionary(uniqueKeysWithValues: processMonitor.apps.map { ($0.bundleID, $0) })
+        let apps = AudioApp.coalescedByBundleID(processMonitor.apps)
+        let running = Dictionary(uniqueKeysWithValues: apps.map { ($0.bundleID, $0) })
 
         for (bundleID, tap) in taps {
             guard let app = running[bundleID] else {

--- a/Fader/FaderApp.swift
+++ b/Fader/FaderApp.swift
@@ -26,9 +26,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        guard !UpdateController.isRelaunchingForUpdate else { return }
+        let isUpdateRelaunch = UpdateController.consumeRelaunchingForUpdate()
+        // Process taps are private to this process and must always be faded and
+        // released. Only the public multi-output aggregate survives an update
+        // relaunch so the incoming instance can adopt it without rerouting.
         Self.engine?.fadeOutAndStop()
-        Self.engine?.multiOutput.shutdown()
+        if !isUpdateRelaunch {
+            Self.engine?.multiOutput.shutdown()
+        }
     }
 }
 

--- a/Fader/UpdateController.swift
+++ b/Fader/UpdateController.swift
@@ -36,6 +36,14 @@ final class UpdateController {
     /// instance to adopt instead of dissolving it.
     private(set) static var isRelaunchingForUpdate = false
 
+    /// Read once by AppDelegate at actual termination. Making the marker
+    /// one-shot prevents it from leaking into any later lifecycle decision.
+    static func consumeRelaunchingForUpdate() -> Bool {
+        let value = isRelaunchingForUpdate
+        isRelaunchingForUpdate = false
+        return value
+    }
+
     static let log = Logger(subsystem: "dev.pantafive.fader", category: "updates")
 
     @ObservationIgnored private var controller: SPUStandardUpdaterController!
@@ -181,6 +189,12 @@ final class UpdateController {
         relaunchHandler?()
     }
 
+    fileprivate func relaunchAborted() {
+        guard Self.isRelaunchingForUpdate else { return }
+        Self.log.info("update relaunch aborted")
+        Self.isRelaunchingForUpdate = false
+    }
+
     private func teardownQuietWatch() {
         if let resignObserver {
             NotificationCenter.default.removeObserver(resignObserver)
@@ -222,6 +236,9 @@ private final class SparkleBridge: NSObject, SPUUpdaterDelegate, @MainActor SPUS
     /// Fires for every aborted cycle, including the benign outcomes already
     /// handled elsewhere — filter those, log the genuine failures.
     func updater(_: SPUUpdater, didAbortWithError error: Error) {
+        // Any aborted Sparkle cycle can be the relaunch attempt returning
+        // without termination. This is a no-op for ordinary background checks.
+        owner?.relaunchAborted()
         let nsError = error as NSError
         if nsError.domain == SUSparkleErrorDomain {
             let benign: [SUError] = [.noUpdateError, .installationCanceledError, .installationAuthorizeLaterError]

--- a/Tests/AudioAppTests.swift
+++ b/Tests/AudioAppTests.swift
@@ -1,0 +1,49 @@
+import CoreAudio
+import Testing
+
+@Suite("AudioApp coalescing")
+struct AudioAppTests {
+    @Test("duplicate bundle IDs merge every HAL process without trapping")
+    func duplicateBundlesMerge() throws {
+        let first = AudioApp(
+            id: 40,
+            bundleID: "com.example.player",
+            name: "Player copy B",
+            objectIDs: [9, 7],
+            isPlaying: false,
+            isRecording: true
+        )
+        let second = AudioApp(
+            id: 20,
+            bundleID: "com.example.player",
+            name: "Player copy A",
+            objectIDs: [7, 3],
+            isPlaying: true,
+            isRecording: false
+        )
+
+        let merged = try #require(AudioApp.coalescedByBundleID([first, second]).first)
+
+        #expect(merged.id == 20)
+        #expect(merged.name == "Player copy A")
+        #expect(merged.objectIDs == [3, 7, 9])
+        #expect(merged.isPlaying)
+        #expect(merged.isRecording)
+    }
+
+    @Test("different bundles retain their first-seen order")
+    func distinctBundlesKeepOrder() {
+        let first = AudioApp(
+            id: 1, bundleID: "com.example.first", name: "First",
+            objectIDs: [1], isPlaying: false, isRecording: false
+        )
+        let second = AudioApp(
+            id: 2, bundleID: "com.example.second", name: "Second",
+            objectIDs: [2], isPlaying: false, isRecording: false
+        )
+
+        #expect(AudioApp.coalescedByBundleID([first, second]).map(\.bundleID) == [
+            "com.example.first", "com.example.second",
+        ])
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -101,6 +101,7 @@ targets:
       - Fader/Audio/JSONDefaults.swift
       - Fader/Audio/DeviceSymbol.swift
       - Fader/Audio/AudioDevice.swift
+      - Fader/Audio/AudioApp.swift
       - Fader/Audio/DevicePriorityPolicy.swift
       - Fader/Audio/MultiOutputPolicy.swift
       - Fader/Audio/VolumeTaper.swift


### PR DESCRIPTION
## Summary
- merge multiple running copies with the same bundle ID into one complete HAL process group
- avoid the duplicate-key main-actor trap while rebuilding process taps
- always fade and release private process taps during an update relaunch
- preserve only the public multi-output aggregate for adoption by the incoming app
- clear the relaunch marker after termination or any aborted Sparkle cycle

## Verification
- make test: 54 tests passed
- SwiftLint: 0 violations