### PR TITLE
fix: recover after Core Audio service restart

### DIFF
--- a/Fader/Audio/AudioDeviceMonitor.swift
+++ b/Fader/Audio/AudioDeviceMonitor.swift
@@ -57,6 +57,25 @@ final class AudioDeviceMonitor {
     func start() {
         lastUsed = usageStore.load()
         ranking = DeviceRanking(order: priorityStore.load(), armed: priorityStore.loadArmed())
+        installListeners()
+        refresh()
+    }
+
+    /// A service reset can preserve UIDs while replacing every AudioObjectID.
+    /// Empty the stale snapshot and suppress hotplug policy until a clean
+    /// baseline has been established from the restarted service.
+    func recoverAfterServiceRestart() {
+        refreshTask?.cancel()
+        refreshTask = nil
+        listeners.removeAll()
+        devices = []
+        defaultDeviceID = .unknown
+        hasBaseline = false
+        installListeners()
+        refresh()
+    }
+
+    private func installListeners() {
         listeners = [
             AudioObjectID.system.listen(kAudioHardwarePropertyDevices) {
                 Task { @MainActor [weak self] in self?.scheduleRefresh() }
@@ -65,7 +84,6 @@ final class AudioDeviceMonitor {
                 Task { @MainActor [weak self] in self?.scheduleRefresh() }
             },
         ]
-        refresh()
     }
 
     func setDefault(_ device: AudioDevice) {

--- a/Fader/Audio/AudioProcessMonitor.swift
+++ b/Fader/Audio/AudioProcessMonitor.swift
@@ -26,10 +26,7 @@ final class AudioProcessMonitor {
 
     func start() {
         guard pollTask == nil else { return } // idempotent: a second call must not double-listen
-        // List changes (process appeared / exited) arrive as HAL notifications.
-        listListener = AudioObjectID.system.listen(kAudioHardwarePropertyProcessObjectList) {
-            Task { @MainActor [weak self] in self?.scheduleRefresh() }
-        }
+        installListListener()
         // Per-process IsRunningOutput flips do NOT arrive in practice
         // (observed on macOS 26), so the playing state is polled. Reading the
         // flags of a few dozen process objects costs microseconds.
@@ -49,9 +46,27 @@ final class AudioProcessMonitor {
         refresh()
     }
 
+    /// Core Audio resets discard client listeners and invalidate process
+    /// object IDs. Keep the inexpensive poll task, but replace the listener
+    /// and published objects before attempting a fresh enumeration.
+    func recoverAfterServiceRestart() {
+        pendingRefresh?.cancel()
+        pendingRefresh = nil
+        apps = []
+        installListListener()
+        refresh()
+    }
+
     deinit {
         pollTask?.cancel()
         pendingRefresh?.cancel()
+    }
+
+    private func installListListener() {
+        // List changes (process appeared / exited) arrive as HAL notifications.
+        listListener = AudioObjectID.system.listen(kAudioHardwarePropertyProcessObjectList) {
+            Task { @MainActor [weak self] in self?.scheduleRefresh() }
+        }
     }
 
     /// Coalesces listener bursts: HAL fires once per process and once per

--- a/Fader/Audio/MixerEngine+ServiceRecovery.swift
+++ b/Fader/Audio/MixerEngine+ServiceRecovery.swift
@@ -1,0 +1,28 @@
+import os
+
+private let audioServiceLogger = Logger(subsystem: "dev.pantafive.fader", category: "MixerEngine")
+
+extension MixerEngine {
+    /// A Core Audio service reset invalidates cached object IDs and every
+    /// listener registered by the client. Recreate all HAL-bound state instead
+    /// of letting stale taps, sliders, and device lists limp on indefinitely.
+    func recoverAfterAudioServiceRestart() {
+        audioServiceLogger.warning("Core Audio service restarted; rebuilding HAL state")
+        prepareForSleep()
+        discardHALBoundState()
+
+        processMonitor.recoverAfterServiceRestart()
+        deviceMonitor.recoverAfterServiceRestart()
+        inputDeviceMonitor.recoverAfterServiceRestart()
+        systemVolume.recoverAfterServiceRestart()
+        inputVolume.recoverAfterServiceRestart()
+        multiOutput.recoverAfterServiceRestart()
+        installHALListeners()
+        bluetooth.refresh()
+        syncTaps()
+
+        // The reset notification can precede the final device publication.
+        // Reuse the bounded wake resync for one tolerant second pass.
+        recoverAfterWake()
+    }
+}

--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -140,35 +140,15 @@ final class MixerEngine {
 
     // MARK: - Private
 
-    /// A Core Audio service reset invalidates cached object IDs and every
-    /// listener registered by the client. Recreate all HAL-bound state instead
-    /// of letting stale taps, sliders, and device lists limp on indefinitely.
-    private func recoverAfterAudioServiceRestart() {
-        Self.logger.warning("Core Audio service restarted; rebuilding HAL state")
-        prepareForSleep()
-
+    func discardHALBoundState() {
         for tap in taps.values {
             tap.invalidate()
         }
         taps.removeAll()
         routeVolumes.removeAll()
-
-        processMonitor.recoverAfterServiceRestart()
-        deviceMonitor.recoverAfterServiceRestart()
-        inputDeviceMonitor.recoverAfterServiceRestart()
-        systemVolume.recoverAfterServiceRestart()
-        inputVolume.recoverAfterServiceRestart()
-        multiOutput.recoverAfterServiceRestart()
-        installHALListeners()
-        bluetooth.refresh()
-        syncTaps()
-
-        // The reset notification can precede the final device publication.
-        // Reuse the bounded wake resync for one tolerant second pass.
-        recoverAfterWake()
     }
 
-    private func installHALListeners() {
+    func installHALListeners() {
         // Rebuild taps when the default output device changes — each aggregate
         // is pinned to a concrete device UID.
         deviceListener = AudioObjectID.system.listen(kAudioHardwarePropertyDefaultOutputDevice) {
@@ -231,7 +211,7 @@ final class MixerEngine {
 
     /// Ensures every non-neutral running app has a live tap covering its
     /// current process set, and every gone app's tap is released.
-    private func syncTaps() {
+    func syncTaps() {
         let running = Dictionary(uniqueKeysWithValues: processMonitor.apps.map { ($0.bundleID, $0) })
 
         for (bundleID, tap) in taps {

--- a/Fader/Audio/MixerEngine.swift
+++ b/Fader/Audio/MixerEngine.swift
@@ -34,6 +34,7 @@ final class MixerEngine {
     @ObservationIgnored private var routeVolumes: [String: DeviceVolumeController] = [:]
     @ObservationIgnored private let store = VolumeStore()
     @ObservationIgnored private var deviceListener: HALListener?
+    @ObservationIgnored private var serviceRestartListener: HALListener?
     @ObservationIgnored private var saveTask: Task<Void, Never>?
     @ObservationIgnored var routingTask: Task<Void, Never>?
     @ObservationIgnored var bluetoothRefreshTask: Task<Void, Never>?
@@ -62,11 +63,7 @@ final class MixerEngine {
         multiOutput.start()
         bluetooth.refresh()
 
-        // Rebuild taps when the default output device changes — each aggregate
-        // is pinned to a concrete device UID.
-        deviceListener = AudioObjectID.system.listen(kAudioHardwarePropertyDefaultOutputDevice) {
-            Task { @MainActor [weak self] in self?.reconcileTapRouting() }
-        }
+        installHALListeners()
 
         observeApps()
         observeDevices()
@@ -142,6 +139,45 @@ final class MixerEngine {
     }
 
     // MARK: - Private
+
+    /// A Core Audio service reset invalidates cached object IDs and every
+    /// listener registered by the client. Recreate all HAL-bound state instead
+    /// of letting stale taps, sliders, and device lists limp on indefinitely.
+    private func recoverAfterAudioServiceRestart() {
+        Self.logger.warning("Core Audio service restarted; rebuilding HAL state")
+        prepareForSleep()
+
+        for tap in taps.values {
+            tap.invalidate()
+        }
+        taps.removeAll()
+        routeVolumes.removeAll()
+
+        processMonitor.recoverAfterServiceRestart()
+        deviceMonitor.recoverAfterServiceRestart()
+        inputDeviceMonitor.recoverAfterServiceRestart()
+        systemVolume.recoverAfterServiceRestart()
+        inputVolume.recoverAfterServiceRestart()
+        multiOutput.recoverAfterServiceRestart()
+        installHALListeners()
+        bluetooth.refresh()
+        syncTaps()
+
+        // The reset notification can precede the final device publication.
+        // Reuse the bounded wake resync for one tolerant second pass.
+        recoverAfterWake()
+    }
+
+    private func installHALListeners() {
+        // Rebuild taps when the default output device changes — each aggregate
+        // is pinned to a concrete device UID.
+        deviceListener = AudioObjectID.system.listen(kAudioHardwarePropertyDefaultOutputDevice) {
+            Task { @MainActor [weak self] in self?.reconcileTapRouting() }
+        }
+        serviceRestartListener = AudioObjectID.system.listen(kAudioHardwarePropertyServiceRestarted) {
+            Task { @MainActor [weak self] in self?.recoverAfterAudioServiceRestart() }
+        }
+    }
 
     private func observeApps() {
         // Re-sync taps whenever the app list changes (launch/quit).

--- a/Fader/Audio/MultiOutputController.swift
+++ b/Fader/Audio/MultiOutputController.swift
@@ -41,6 +41,21 @@ final class MultiOutputController {
 
     func start() {
         adoptOrDestroyLeftover()
+        installDefaultListener()
+    }
+
+    /// Public aggregates may survive an audio-service reset under a new object
+    /// ID. Forget all cached HAL identities, then adopt the live aggregate only
+    /// when it is still the default; otherwise fail safe to the system route.
+    func recoverAfterServiceRestart() {
+        aggregateID = .unknown
+        members = []
+        defaultListener = nil
+        adoptOrDestroyLeftover()
+        installDefaultListener()
+    }
+
+    private func installDefaultListener() {
         // Output switched elsewhere (Control Center, Sound settings, a device
         // row click) means the aggregate left the audio path — dissolve.
         defaultListener = AudioObjectID.system.listen(kAudioHardwarePropertyDefaultOutputDevice) {

--- a/Fader/Audio/SystemVolumeController.swift
+++ b/Fader/Audio/SystemVolumeController.swift
@@ -43,10 +43,24 @@ final class SystemVolumeController {
     #endif
 
     func start() {
+        installDefaultDeviceListener()
+        attachToDefaultDevice()
+    }
+
+    /// Replaces both the system and device listeners after Core Audio reset;
+    /// their registrations and the endpoint object ID are no longer valid.
+    func recoverAfterServiceRestart() {
+        defaultDeviceListener = nil
+        deviceListeners.removeAll()
+        endpoint.deviceID = .unknown
+        installDefaultDeviceListener()
+        attachToDefaultDevice()
+    }
+
+    private func installDefaultDeviceListener() {
         defaultDeviceListener = AudioObjectID.system.listen(direction.defaultDeviceSelector) {
             Task { @MainActor [weak self] in self?.attachToDefaultDevice() }
         }
-        attachToDefaultDevice()
     }
 
     func setVolume(_ value: Float) {


### PR DESCRIPTION
## Summary
- listen for Core Audio service reset notifications
- discard stale taps, object IDs, endpoints, and device snapshots after a reset
- reinstall every HAL listener and perform an immediate plus delayed resync
- safely re-adopt a surviving multi-output aggregate by UID

## Verification
- make test (52 tests)
- MISE_SHELLCHECK_VERSION=0.11.0 make lint
- combined seven-PR integration: 58 tests and full lint

## Dependency
Stacked on #34 because it reuses the bounded wake/HAL resync path. After #34 merges, retarget this PR to main before merging it.