### PR TITLE
Bump Sparkle to 2.9.6 for upstream security fixes

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -8,7 +8,7 @@ options:
 packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
-    exactVersion: 2.9.5
+    exactVersion: 2.9.6
 
 settings:
   base:

--- a/scripts/install-ci-tools.sh
+++ b/scripts/install-ci-tools.sh
@@ -10,8 +10,8 @@ SWIFTLINT_SHA256=d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba
 SWIFTFORMAT_VERSION=0.62.1
 SWIFTFORMAT_SHA256=7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a
 # Keep in sync with the SPM pin in project.yml.
-SPARKLE_VERSION=2.9.5
-SPARKLE_SHA256=015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc
+SPARKLE_VERSION=2.9.6
+SPARKLE_SHA256=52bf9e88cdd972fc0c81501377a880e90d47031bd8ca5462488f843e2609e192
 
 # A project.yml-only Sparkle bump would ship a framework newer than the
 # sign_update CLI with no error anywhere — refuse to drift.


### PR DESCRIPTION
## Summary
- `project.yml` pins the Sparkle SPM package at `2.9.5`, and `scripts/install-ci-tools.sh` pins the matching `sign_update` download at the same version+checksum.
- Sparkle's [2.9.6 release notes](https://github.com/sparkle-project/Sparkle/releases/tag/2.9.6) describe it as containing security fixes: hardened handling of the downloaded archive during install, and removal of the root-owned cache directory usage that could otherwise be abused for local privilege escalation on processes running Sparkle as root. Background in [sparkle-project/Sparkle#2838](https://github.com/sparkle-project/Sparkle/discussions/2838).
- This bumps both pins to `2.9.6` together, following the existing "keep in sync" convention already enforced by the version-match check at the top of `install-ci-tools.sh`.

## Test plan
- [x] Ran `scripts/install-ci-tools.sh` locally end to end — the new `SPARKLE_SHA256` value verifies against the actual `Sparkle-2.9.6.tar.xz` release asset and `sign_update` extracts successfully.
- [ ] CI (`ci.yml`) build/test/lint on this PR.